### PR TITLE
Fix [TIMOB-24662] CLI: Build errors out with "Couldn't find preset "babili" relative to directory" when deploy type is test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This is the Titanium SDK common library used for all SDK specific CLI commands.
 This project is open source and provided under the Apache Public License (version 2). Please make sure you see the `LICENSE` file
 included in this distribution for more details on the license.  Also, please take notice of the privacy notice at the end of the file.
 
-#### (C) Copyright 2012, [Appcelerator](http://www.appcelerator.com/) Inc. All Rights Reserved.
+#### (C) Copyright 2012-2017, [Appcelerator](http://www.appcelerator.com/) Inc. All Rights Reserved.

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -19,6 +19,7 @@ var appc = require('node-appc'),
 	babylon = require('babylon'),
 	types = require('babel-types'),
 	traverse = require('babel-traverse').default,
+	babili = require.resolve('babel-preset-babili'),
 	__ = appc.i18n(__dirname).__,
 	apiUsage = {};
 
@@ -109,7 +110,7 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 
 	// parse the js file
 	try {
-		ast = babylon.parse(contents, { sourceFilename: opts.filename });
+		ast = babylon.parse(contents, { filename: opts.filename });
 	} catch (ex) {
 		var errmsg = [ __('Failed to parse %s', opts.filename) ];
 		if (ex.line) {
@@ -161,7 +162,8 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 
 	// minify
 	if (opts.minify) {
-		var minified = babel.transformFromAst(ast, contents, {minified: true, compact: true, comments: false, presets: ['babili']});
+		// FIXME we can't re-use the ast here, because we traversed it
+		var minified = babel.transform(contents, {filename: opts.filename, minified: true, compact: true, comments: false, presets: [babili]});
 		results.contents = minified.code;
 	}
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
- Need to resolve path to babel preset using require, otherwise it looks for rest to be installed in the user's project.
- Use babel.transform to minify since once we traverse an AST we can re-use it. Long-term fix would be to make our code that does Ti.* symbol searches a babel plugin so we can do one pass with it and presets.