### PR TITLE
[TIMOB-24750] Only configure target platform

### DIFF
--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -52,7 +52,8 @@ exports.commonOptions = function (logger, config) {
 };
 
 exports.platformOptions = function (logger, config, cli, commandName, finished) {
-	var result = {};
+	var result = {},
+		targetPlatform = cli.argv['platform'] || cli.argv['p'];
 
 	if (!commandName) {
 		finished(result);
@@ -75,6 +76,12 @@ exports.platformOptions = function (logger, config, cli, commandName, finished) 
 	// for each platform, fetch their specific flags/options
 	async.parallel(manifest.platforms.map(function (platform) {
 		return function (callback) {
+
+			// only configure target platform
+			if (targetPlatform && platform != targetPlatform) {
+				return callback();
+			}
+
 			var platformDir = path.join(path.dirname(module.filename), '..', '..', '..', platform),
 				platformCommand = path.join(platformDir, 'cli', 'commands', '_' + commandName + '.js'),
 				command,

--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -53,7 +53,7 @@ exports.commonOptions = function (logger, config) {
 
 exports.platformOptions = function (logger, config, cli, commandName, finished) {
 	var result = {},
-		targetPlatform = cli.argv['platform'] || cli.argv['p'];
+		targetPlatform = !cli.argv.help && (cli.argv.platform || cli.argv.p);
 
 	if (!commandName) {
 		finished(result);
@@ -78,7 +78,7 @@ exports.platformOptions = function (logger, config, cli, commandName, finished) 
 		return function (callback) {
 
 			// only configure target platform
-			if (targetPlatform && platform != targetPlatform) {
+			if (targetPlatform && platform !== targetPlatform) {
 				return callback();
 			}
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
- Only configure the platform we intent to build, for faster build times

##### TEST CASE
- Should not configure `windows` or `ios`
```
appc run -p android --build-only
```

###### NOTES: Unfortunately `cli.argv.platform` is not defined at this point in the process