### PR TITLE
[TIMOB-24787] Fixed issue when .DS_Store exists in build-tools dir

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -40,7 +40,10 @@ var fs = require('fs'),
 		'dx': bat
 	},
 	pkgPropRegExp = /^([^=]*)=\s*(.+)$/,
-	envCache;
+	envCache,
+	ignoreFiles = [
+		'.DS_Store'
+	];
 
 // need to find the android module and its package.json
 (function findPackageJson(dir) {
@@ -757,7 +760,7 @@ function findSDK(dir, config, androidPackageJson, callback) {
 			ver = config.get('android.buildTools.selectedVersion');
 		if (!ver) {
 			// No selected version, so find the newest, supported build tools version
-			var files = fs.readdirSync(buildToolsDir).sort().reverse(),
+			var files = fs.readdirSync(buildToolsDir).sort().reverse().filter(file => ignoreFiles.indexOf(file) >= 0),
 				i=0,
 				len = files.length,
 				buildToolsSupported;

--- a/lib/android.js
+++ b/lib/android.js
@@ -40,10 +40,7 @@ var fs = require('fs'),
 		'dx': bat
 	},
 	pkgPropRegExp = /^([^=]*)=\s*(.+)$/,
-	envCache,
-	ignoreFiles = [
-		'.DS_Store'
-	];
+	envCache;
 
 // need to find the android module and its package.json
 (function findPackageJson(dir) {
@@ -760,7 +757,9 @@ function findSDK(dir, config, androidPackageJson, callback) {
 			ver = config.get('android.buildTools.selectedVersion');
 		if (!ver) {
 			// No selected version, so find the newest, supported build tools version
-			var files = fs.readdirSync(buildToolsDir).sort().reverse().filter(file => ignoreFiles.indexOf(file) >= 0),
+			var ignoreDirs = new RegExp(config.get('cli.ignoreDirs'))
+			var ignoreFiles = new RegExp(config.get('cli.ignoreFiles'))
+			var files = fs.readdirSync(buildToolsDir).sort().reverse().filter(item => !(ignoreFiles.test(item) || ignoreDirs.test(item))),
 				i=0,
 				len = files.length,
 				buildToolsSupported;

--- a/lib/android.js
+++ b/lib/android.js
@@ -757,8 +757,8 @@ function findSDK(dir, config, androidPackageJson, callback) {
 			ver = config.get('android.buildTools.selectedVersion');
 		if (!ver) {
 			// No selected version, so find the newest, supported build tools version
-			var ignoreDirs = new RegExp(config.get('cli.ignoreDirs'))
-			var ignoreFiles = new RegExp(config.get('cli.ignoreFiles'))
+			var ignoreDirs = new RegExp(config.get('cli.ignoreDirs'));
+			var ignoreFiles = new RegExp(config.get('cli.ignoreFiles'));
 			var files = fs.readdirSync(buildToolsDir).sort().reverse().filter(item => !(ignoreFiles.test(item) || ignoreDirs.test(item))),
 				i=0,
 				len = files.length,


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24787

- Filter the files based off an ignoreFiles list

- I think we should do the following also
    - Update the node-appc check to prevent this bug occuring in other places in the future, i.e. validate the range passed in there too, rather than expecting it to be done in every place we use node-appc.version.whatever

# Verification

1. Install a version of Android build-tools that is lower than the minimum required version (or edit the minimum in the SDK to be higher than whatever you have)
2. Build a project for Android
  - Should not error out with the error in ticket description, should throw an error about `Missing required Android SDK tools:`