### PR TITLE
[TIMOB-24906] Android: Delay sending initial adb command

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -105,7 +105,12 @@ Connection.prototype.exec = function exec(cmd, callback, opts) {
 			port: this.port
 		}, function () {
 			DEBUG && console.log('[' + this.connNum + '] CONNECTED');
-			send();
+
+			// TIMOB-24906: in some circumstances sending a command to adb right away
+			// can yield no response. So we allow 100ms before sending the initial command
+			setTimeout(function() {
+				send();
+			}, 100);
 		}.bind(this));
 
 		socket.setKeepAlive(true);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
- Induce a 100ms delay before sending the initial `ADB.exec()` command

###### TEST CASE
- Close all running emulators
- Repeat `run` command a number of times
```
appc run -p android -T emulator
```

###### EXPECTED
- Should not see error below, project should run on emulator
```
[ERROR] Failed to install apk on "emulator-5554"
[ERROR] Error: device not found
```

##### NOTE: this issue is commonly reproduced on Windows

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24906)