### PR TITLE
Add an export to provide the full array of all platform names we've supported.

### DIFF
--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -36,6 +36,7 @@ exports.availablePlatformsNames = function (platforms) {
 	});
 	return platforms.sort();
 }(manifest.platforms || []);
+exports.allPlatformNames = ['android', 'ios', 'iphone', 'ipad', 'mobileweb', 'blackberry', 'windows', 'tizen'];
 
 exports.commonOptions = function (logger, config) {
 	return {
@@ -486,10 +487,6 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 						cmdAdd('adhoc', argv['ios-version'], argv['project-dir'], tiapp.id, tiapp.name, argv['pp-uuid'], argv['distribution-name'], argv['device-family'], argv.keychain, argv['debug-host']);
 						break;
 				}
-				break;
-
-			case 'mobileweb':
-				cmdAdd(argv['project-dir'], argv['deploy-type']);
 				break;
 
 			case 'android':

--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -489,6 +489,10 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 				}
 				break;
 
+			case 'mobileweb':
+				cmdAdd(argv['project-dir'], argv['deploy-type']);
+				break;
+
 			case 'android':
 				if (argv['build-only']) {
 					cmdAdd('build', tiapp.name, argv['android-sdk'], argv['project-dir'] , tiapp.id);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
Best used to filter platform-specific subdirectories of Resources in apps. This is preferred over availablePlatformNames which just gives you the list of available platforms for the given SDK version and OS (so for example we'll end up copying windows subdirectories on a mac build of a cross-platform app). We "fixed" this in the iOS build to use a regexp, but never fixed it in Android. I decided it'd be best to migrate the array to node-titanium-sdk as an export.