### PR TITLE
[TIMOB-24900] Support Android O changes

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -580,8 +580,8 @@ ADB.prototype.ps = function ps(deviceId, callback) {
 			callback(err);
 		} else {
 			// old ps, does not support '-A' parameter
-			var dataStr = data.toString();
-			if (dataStr.startsWith('bad pid \'-A\'') || dataStr.endsWith('NAME\r\n')) {
+			var dataStr = data.toString().trim();
+			if (dataStr.startsWith('bad pid \'-A\'') || dataStr.endsWith('NAME')) {
 				this.shell(deviceId, 'ps', output);
 			} else {
 				callback(null, data);

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -580,7 +580,8 @@ ADB.prototype.ps = function ps(deviceId, callback) {
 			callback(err);
 		} else {
 			// old ps, does not support '-A' parameter
-			if (data.toString().startsWith('bad pid \'-A\'')) {
+			var dataStr = data.toString();
+			if (dataStr.startsWith('bad pid \'-A\'') || dataStr.endsWith('NAME\r\n')) {
 				this.shell(deviceId, 'ps', output);
 			} else {
 				callback(null, data);

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -259,7 +259,7 @@ Connection.prototype.exec = function exec(cmd, callback, opts) {
 				case WAIT_FOR_RESPONSE:
 					DEBUG && console.log('[' + this.connNum + '] DONE, RECEIVED RESPONSE');
 					this.state = DO_NOTHING;
-					socket.end();
+					callback(null, buffer);
 					return;
 			}
 		}
@@ -268,7 +268,9 @@ Connection.prototype.exec = function exec(cmd, callback, opts) {
 	socket.on('end', function () {
 		DEBUG && console.log('[' + this.connNum + '] SOCKET CLOSED BY SERVER', (buffer && buffer.length));
 		if (buffer && buffer.length) {
-			callback(null, buffer);
+			if (!this.opts.waitForResponse) {
+				callback(null, buffer);
+			}
 			buffer = null;
 		}
 		this.end();

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -62,6 +62,12 @@ const WAIT_FOR_NEW_DATA = 2;
 const BUFFER_UNTIL_CLOSE = 3;
 
 /**
+ * @constant
+ * After a command is executed, wait for a response before executing the callback
+ */
+const WAIT_FOR_RESPONSE = 4;
+
+/**
  * Creates an Connection object.
  * @class
  * @classdesc Manages the connection and communcations with the ADB server.
@@ -107,10 +113,10 @@ Connection.prototype.exec = function exec(cmd, callback, opts) {
 			DEBUG && console.log('[' + this.connNum + '] CONNECTED');
 
 			// TIMOB-24906: in some circumstances sending a command to adb right away
-			// can yield no response. So we allow 100ms before sending the initial command
+			// can yield no response. So we allow 200ms before sending the initial command
 			setTimeout(function() {
 				send();
-			}, 100);
+			}, 200);
 		}.bind(this));
 
 		socket.setKeepAlive(true);
@@ -171,6 +177,9 @@ Connection.prototype.exec = function exec(cmd, callback, opts) {
 						if (this.opts.bufferUntilClose) {
 							DEBUG && console.log('[' + this.connNum + '] DONE, SETTING STATE TO BUFFER_UNTIL_CLOSE');
 							this.state = BUFFER_UNTIL_CLOSE;
+						} else if (this.opts.waitForResponse) {
+							DEBUG && console.log('[' + this.connNum + '] DONE, SETTING STATE TO WAIT_FOR_RESPONSE');
+							this.state = WAIT_FOR_RESPONSE;
 						} else {
 							DEBUG && console.log('[' + this.connNum + '] DONE, SETTING STATE TO DO_NOTHING');
 							this.state = DO_NOTHING;
@@ -246,6 +255,11 @@ Connection.prototype.exec = function exec(cmd, callback, opts) {
 
 				case BUFFER_UNTIL_CLOSE:
 					// we've already added data to the buffer
+					return;
+				case WAIT_FOR_RESPONSE:
+					DEBUG && console.log('[' + this.connNum + '] DONE, RECEIVED RESPONSE');
+					this.state = DO_NOTHING;
+					socket.end();
 					return;
 			}
 		}
@@ -431,7 +445,7 @@ ADB.prototype.trackDevices = function trackDevices(callback) {
 
 	conn.exec('host:track-devices', function (err, data) {
 		queue.push({ err: err, data: data });
-	});
+	}, { waitForResponse: true });
 
 	return conn;
 };
@@ -554,13 +568,34 @@ ADB.prototype.installApp = function installApp(deviceId, apkFile, opts, callback
 };
 
 /**
+ * Returns the ps output of the specified app and device/emulator, if running.
+ * @param {String} deviceId - The id of the device or emulator
+ * @param {ADB~psCallback} callback - A callback that is fired once ps is executed
+ */
+ADB.prototype.ps = function ps(deviceId, callback) {
+	var output = function (err, data) {
+		if (err) {
+			callback(err);
+		} else {
+			// old ps, does not support '-A' parameter
+			if (data.toString().startsWith('bad pid \'-A\'')) {
+				this.shell(deviceId, 'ps', output);
+			} else {
+				callback(null, data);
+			}
+		}
+	}.bind(this);
+	this.shell(deviceId, 'ps -A', output);
+};
+
+/**
  * Returns the pid of the specified app and device/emulator, if running.
  * @param {String} deviceId - The id of the device or emulator
  * @param {String} appid - The application's id
  * @param {ADB~getPidCallback} callback - A callback that is fired once the pid has been determined
  */
 ADB.prototype.getPid = function getPid(deviceId, appid, callback) {
-	this.shell(deviceId, 'ps', function (err, data) {
+	this.ps(deviceId, function (err, data) {
 		if (err) {
 			callback(err);
 		} else {

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -575,20 +575,20 @@ ADB.prototype.installApp = function installApp(deviceId, apkFile, opts, callback
  * @param {ADB~psCallback} callback - A callback that is fired once ps is executed
  */
 ADB.prototype.ps = function ps(deviceId, callback) {
-	var output = function (err, data) {
+	var outputCallback = function (err, data) {
 		if (err) {
 			callback(err);
 		} else {
 			// old ps, does not support '-A' parameter
 			var dataStr = data.toString().trim();
 			if (dataStr.startsWith('bad pid \'-A\'') || dataStr.endsWith('NAME')) {
-				this.shell(deviceId, 'ps', output);
+				this.shell(deviceId, 'ps', outputCallback);
 			} else {
 				callback(null, data);
 			}
 		}
 	}.bind(this);
-	this.shell(deviceId, 'ps -A', output);
+	this.shell(deviceId, 'ps -A', outputCallback);
 };
 
 /**

--- a/lib/emulators/avd.js
+++ b/lib/emulators/avd.js
@@ -239,8 +239,7 @@ exports.start = function start(config, emu, opts, callback) {
 				var args = [
 					'-avd', emu.id,                                  // use a specific android virtual device
 					'-port', port,                                   // TCP port that will be used for the console
-					'-no-boot-anim',                                 // disable animation for faster boot
-					'-partition-size', opts.partitionSize || 128     // system/data partition size in MBs
+					'-partition-size', opts.partitionSize || 512     // system/data partition size in MBs
 				];
 
 				var sdcard = opts.sdcard || emu.sdcard;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
- Increase `100ms` delay to `200ms` before sending command
- Implement `waitForResponse` for `trackDevices` as the initial response may not contain any response data
- `ps` now requires the `-A` parameter to list all process results. Implement backwards-compatible `adb.ps` method
- Fix `getPid` to use new `adb.ps` method
- Remove `-no-boot-anim` as this flag prevents the Android O emulator from booting
- Increase `-partition-size` to `512`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24900)