### PR TITLE
[TIMOB-25160] Updated adb devices call to parse device info from 'get…

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -374,7 +374,7 @@ function parseDevices(adb, callback, err, data) {
 				if (!err && data) {
 					const re = /^\[([^\]]*)\]: \[(.*)\]\s*$/;
 					data.toString().split('\n').forEach(function (line) {
-						var m = line.match(re);
+						const m = line.match(re);
 						if (m) {
 							var key = m[1];
 							var value = m[2];

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -376,8 +376,8 @@ function parseDevices(adb, callback, err, data) {
 					data.toString().split('\n').forEach(function (line) {
 						const m = line.match(re);
 						if (m) {
-							var key = m[1];
-							var value = m[2];
+							const key = m[1];
+							const value = m[2];
 
 							switch (key) {
 								case 'ro.product.model.internal':

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -8,7 +8,7 @@
  * @module adb
  *
  * @copyright
- * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2017 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -370,14 +370,16 @@ function parseDevices(adb, callback, err, data) {
 				return;
 			}
 
-			adb.shell(info.id, 'cat /system/build.prop', function (err, data) {
+			adb.shell(info.id, 'getprop', function (err, data) {
 				if (!err && data) {
+					const re = /^\[([^\]]*)\]: \[(.*)\]\s*$/;
 					data.toString().split('\n').forEach(function (line) {
-						var p = line.indexOf('='),
-							key, value;
-						if (p != -1) {
-							value = line.substring(p + 1).trim();
-							switch (key = line.substring(0, p)) {
+						var m = line.match(re);
+						if (m) {
+							var key = m[1];
+							var value = m[2];
+
+							switch (key) {
 								case 'ro.product.model.internal':
 									info.modelnumber = value;
 									break;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
[TIMOB-25160] Updated adb devices call to parse device info from 'getprop' instead of cat'ing the build.prop file.

JIRA: https://jira.appcelerator.org/browse/TIMOB-25160