### PR TITLE
[TIMOB-24906] Android: Wait for response when parsing devices

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -178,8 +178,8 @@ Connection.prototype.exec = function exec(cmd, callback, opts) {
 							DEBUG && console.log('[' + this.connNum + '] DONE, SETTING STATE TO BUFFER_UNTIL_CLOSE');
 							this.state = BUFFER_UNTIL_CLOSE;
 						} else if (this.opts.waitForResponse) {
-							DEBUG && console.log('[' + this.connNum + '] DONE, SETTING STATE TO WAIT_FOR_RESPONSE');
-							this.state = WAIT_FOR_RESPONSE;
+							DEBUG && console.log('[' + this.connNum + '] DONE, SETTING STATE TO WAIT_FOR_NEW_DATA');
+							this.state = WAIT_FOR_NEW_DATA;
 						} else {
 							DEBUG && console.log('[' + this.connNum + '] DONE, SETTING STATE TO DO_NOTHING');
 							this.state = DO_NOTHING;
@@ -429,7 +429,7 @@ function parseDevices(adb, callback, err, data) {
 ADB.prototype.devices = function devices(callback) {
 	new Connection(this).exec('host:devices', function (err, data) {
 		parseDevices(this, callback, err, data);
-	}.bind(this));
+	}.bind(this), { waitForResponse: true });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.4.4",
+	"version": "0.4.5",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
- When parsing `adb devices`, always wait for response data instead of just a response

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24906)