### PR TITLE
[TIMOB-25742] Fixed adb issue where it fails to install to Android 4.1 devices

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -539,8 +539,9 @@ ADB.prototype.installApp = function installApp(deviceId, apkFile, opts, callback
 		this.devices(function (err, devices) {
 			if (err) return callback(err);
 
-			devices = devices.filter(function (d) { return d.id == deviceId });
-			if (devices.length != 1) return callback(new Error(__('device not found')));
+			// Fetch info about the device we're installing to.
+			devices = devices.filter(function (d) { return d.id === deviceId });
+			if (devices.length < 1) return callback(new Error(__('device not found')));
 			const deviceInfo = devices[0];
 
 			androidDetect(this.config, function (err, results) {
@@ -556,20 +557,20 @@ ADB.prototype.installApp = function installApp(deviceId, apkFile, opts, callback
 				}
 
 				// Set up the 'adb' arguments array.
-				let arguments = [];
-				arguments.push('-s', deviceId);
-				arguments.push('install');
-				arguments.push('-r');
+				const args = [];
+				args.push('-s', deviceId);
+				args.push('install');
+				args.push('-r');
 				if (deviceApiLevel >= 17) {
-					// Set the '-d' argument to install an older APK over a new one.
+					// Allow installation of an older APK version over a newer one.
 					// Note: Only supported on Android 4.2 (API Level 17) and higher.
-					arguments.push('-d');
+					args.push('-d');
 				}
-				arguments.push(apkFile);
+				args.push(apkFile);
 
 				// Run the adb install command.
-				opts.logger && opts.logger.trace(__('Executing: %s', [results.sdk.executables.adb].concat(arguments).join(' ').cyan));
-				appc.subprocess.run(results.sdk.executables.adb, arguments, function (code, out, err) {
+				opts.logger && opts.logger.trace(__('Executing: %s', [results.sdk.executables.adb].concat(args).join(' ').cyan));
+				appc.subprocess.run(results.sdk.executables.adb, args, function (code, out, err) {
 					var m = out.match(/^Failure \[(.+)\]$/m);
 					if ((code && err.indexOf('No space left on device') != -1) || (!code && m && m[1] == 'INSTALL_FAILED_INSUFFICIENT_STORAGE')) {
 						callback(new Error(__('Not enough free space on device')));

--- a/lib/adb.js
+++ b/lib/adb.js
@@ -538,14 +538,38 @@ ADB.prototype.installApp = function installApp(deviceId, apkFile, opts, callback
 	} else {
 		this.devices(function (err, devices) {
 			if (err) return callback(err);
-			if (devices.filter(function (d) { return d.id == deviceId }).length != 1) return callback(new Error(__('device not found')));
+
+			devices = devices.filter(function (d) { return d.id == deviceId });
+			if (devices.length != 1) return callback(new Error(__('device not found')));
+			const deviceInfo = devices[0];
 
 			androidDetect(this.config, function (err, results) {
 				if (err) return callback(err);
 
-				opts.logger && opts.logger.trace(__('Executing: %s', [results.sdk.executables.adb, '-s', deviceId, 'install', '-r', '-d', apkFile].join(' ').cyan));
+				// Fetch the device's API Level.
+				let deviceApiLevel = 1;
+				if (deviceInfo.sdk) {
+					const value = parseInt(deviceInfo.sdk);
+					if (!isNaN(value)) {
+						deviceApiLevel = value;
+					}
+				}
 
-				appc.subprocess.run(results.sdk.executables.adb, ['-s', deviceId, 'install', '-r', '-d', apkFile], function (code, out, err) {
+				// Set up the 'adb' arguments array.
+				let arguments = [];
+				arguments.push('-s', deviceId);
+				arguments.push('install');
+				arguments.push('-r');
+				if (deviceApiLevel >= 17) {
+					// Set the '-d' argument to install an older APK over a new one.
+					// Note: Only supported on Android 4.2 (API Level 17) and higher.
+					arguments.push('-d');
+				}
+				arguments.push(apkFile);
+
+				// Run the adb install command.
+				opts.logger && opts.logger.trace(__('Executing: %s', [results.sdk.executables.adb].concat(arguments).join(' ').cyan));
+				appc.subprocess.run(results.sdk.executables.adb, arguments, function (code, out, err) {
 					var m = out.match(/^Failure \[(.+)\]$/m);
 					if ((code && err.indexOf('No space left on device') != -1) || (!code && m && m[1] == 'INSTALL_FAILED_INSUFFICIENT_STORAGE')) {
 						callback(new Error(__('Not enough free space on device')));


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25742

**Summary:**
- Was failing to install because our `adb install` command was passing argument `-d`, which is only supported on Android 4.2 and higher.
- Now checks the device's API Level and only adds the `-d` argument if supported on device.
- Note that install was failing near the end of the install, once the APK had been finished copying over to the device. So, it's better to check device API Level in advance for best performance.

**Test:**
Run the test attached to [TIMOB-25742](https://jira.appcelerator.org/browse/TIMOB-25742).