### PR TITLE
[TIMOB-25865] Android: Modified CLI to not select "build-tools" version newer than supported if a supported version is installed

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -451,20 +451,27 @@ exports.detect = function detect(config, opts, finished) {
 
 		// check if the sdk is missing any commands
 		var missing = Object.keys(requiredSdkTools).filter(function (cmd) { return !results.sdk.executables[cmd]; });
-		if (missing.length) {
+		if (missing.length || !results.sdk.buildTools.supported) {
 			var dummyPath = path.join(path.resolve('/'), 'path', 'to', 'android-sdk'),
-				msg = __n('Missing required Android SDK tool: %%s', 'Missing required Android SDK tools: %%s', missing.length, '__' + missing.join(', ') + '__') + '\n\n'
-					+ __('The Android SDK located at %s has incomplete or out-of-date packages.', '__' + results.sdk.path + '__') + '\n\n'
-					+ __('Current installed Android SDK tools:') + '\n'
-					+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '\n'
-					+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '\n'
-					+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '\n\n'
-					+ __('Make sure you have the latest Android SDK Tools, Platform Tools, and Build Tools installed.') + '\n\n'
-					+ __('You can also specify the exact location of these required tools by running:') + '\n';
+				msg = "";
 
-			missing.forEach(function (m) {
-				msg += '  ' + commandPrefix + 'ti config android.executables.' + m + ' "' + path.join(dummyPath, m + requiredSdkTools[m]) + '"\n';
-			});
+			if (missing.length) {
+				msg += __n('Missing required Android SDK tool: %%s', 'Missing required Android SDK tools: %%s', missing.length, '__' + missing.join(', ') + '__') + '\n\n';
+			}
+
+			msg += __('The Android SDK located at %s has incomplete or out-of-date packages.', '__' + results.sdk.path + '__') + '\n\n'
+				+ __('Current installed Android SDK tools:') + '\n'
+				+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')' + '\n'
+				+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')' + '\n'
+				+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android build tools'] + ')' + '\n\n'
+				+ __('Make sure you have the latest Android SDK Tools, Platform Tools, and Build Tools installed.') + '\n';
+
+			if (missing.length) {
+				msg += '\n' + __('You can also specify the exact location of these required tools by running:') + '\n';
+				missing.forEach(function (m) {
+					msg += '  ' + commandPrefix + 'ti config android.executables.' + m + ' "' + path.join(dummyPath, m + requiredSdkTools[m]) + '"\n';
+				});
+			}
 
 			msg += '\n' + __('If you need to, run "%s" to reconfigure the Titanium Android settings.', commandPrefix + 'titanium setup android');
 
@@ -765,10 +772,22 @@ function findSDK(dir, config, androidPackageJson, callback) {
 				len = files.length,
 				buildToolsSupported;
 			for(; i < len; i++) {
-				if (buildToolsSupported = appc.version.satisfies(files[i], androidPackageJson.vendorDependencies['android build tools'], true)) {
+				var isSupported = appc.version.satisfies(files[i], androidPackageJson.vendorDependencies['android build tools'], true);
+				if (isSupported) {
+					buildToolsSupported = isSupported;
 					ver = files[i];
-					break;
+					if (buildToolsSupported == true) {
+						// The version found is fully supported (not set to 'maybe'). So, stop here.
+						break;
+					}
 				}
+			}
+
+			// If we've failed to find a build-tools version that Titanium supports up above,
+			// then grab the newest old version installed to be logged as unsupported later.
+			if (!ver && (len > 0)) {
+				ver = files[len - 1];
+				buildToolsSupported = false;
 			}
 		}
 		if (ver) {

--- a/lib/android.js
+++ b/lib/android.js
@@ -453,7 +453,7 @@ exports.detect = function detect(config, opts, finished) {
 		var missing = Object.keys(requiredSdkTools).filter(function (cmd) { return !results.sdk.executables[cmd]; });
 		if (missing.length || !results.sdk.buildTools.supported) {
 			var dummyPath = path.join(path.resolve('/'), 'path', 'to', 'android-sdk'),
-				msg = "";
+				msg = '';
 
 			if (missing.length) {
 				msg += __n('Missing required Android SDK tool: %%s', 'Missing required Android SDK tools: %%s', missing.length, '__' + missing.join(', ') + '__') + '\n\n';


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-25865

**Summary:**
- This avoids an unnecessary "too new" warning from being logged after every build. Will now use the preferred build-tools version instead of always selecting newest version.
- Modified to log which version(s) are supported _(in parenthesis)_ if installed build-tools, platform-tools, and SDK is older than supported. This way the end-user has a clue on what to install.

**Note:**
Our `appc.version.satisfies()` function returns boolean values `true` and `false`... as well as the string `'maybe'` if above supported version range (ie: too new). Doing an if-check on the `'maybe'` string was what was biting us here.

---
**Test:**
1. Open the Android SDK Manager.
2. Install "build-tools" versions 27.x and 26.x, if not done already.
3. Build a Titanium project for Android.
4. Observe the build log and verify that a warning similar to the below is **NOT** logged.
```
[WARN] :   Android Build Tools 27.0.3 are too new and may or may not work with Titanium.
[WARN] :   If you encounter problems, select a supported version with:
[WARN] :      appc ti config android.buildTools.selectedVersion ##.##.##
[WARN] :    where ##.##.## is a version in /Users/user/Library/Android/sdk/build-tools that is 26.x
```
5. Go to the Android SDK's "build-tools" directory in Finder or Explorer. On Mac, the default location is: `~/Library/Android/sdk/build-tools`
6. Under the "build-tools" directory, there should be multiple subdirectories named after the build-tools versions installed such as "26.0.1" and "27.0.3".
7. Move all subdirectory build-tools versions older than version 27 to the desktop. (We'll move them back after the test.)
8. Re-build the Titanium project for Android and observe the log.
9. Verify that you do see the "too new" warning message mentioned in step **4** above.
10. Move all of the remaining "build-tools" version subdirectories to you desktop (this includes v27 subdirectories).
11. Re-build the Titanium project for Android  and observe the log.
12. Verify something similar to the following gets displayed. The "(Supported: version)" in parenthesis is something new this PR is logging.
```
[ERROR] :  The Android SDK located at /Users/user/Library/Android/sdk has incomplete or out-of-date packages.
[ERROR] :  
[ERROR] :  Current installed Android SDK tools:
[ERROR] :    Android SDK Tools:          25.2.5  (Supported: <=26.x)
[ERROR] :    Android SDK Platform Tools: 27.0.1  (Supported: 26.x)
[ERROR] :    Android SDK Build Tools:    not installed  (Supported: 26.x)
```
13. Move the "build-tools" subdirectories back to their prior location to restore what you previously had installed.
