### PR TITLE
[TIMOB-26099] Android: Modified "appc run" to launch app with same intent as Android OS when tapping app

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -653,7 +653,13 @@ ADB.prototype.getPid = function getPid(deviceId, appid, callback) {
  * @param {ADB~startAppCallback} callback - A function that is called once the application has been started
  */
 ADB.prototype.startApp = function startApp(deviceId, appid, activity, callback) {
-	this.shell(deviceId, 'am start ' + appid + '/.' + activity.replace(/^\./, ''), callback);
+	// This launches the app via an intent just like how the Android OS would do it when tapping on the app.
+	// Notes:
+	// - The "-n" sets the intent's component name. Needed by explicit intents.
+	// - The "-a" sets the intent's action.
+	// - The "-c" sets the intent's category.
+	// - The "-f 0x10200000" sets intent flags: FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
+	this.shell(deviceId, 'am start -n ' + appid + '/.' + activity.replace(/^\./, '') + ' -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -f 0x10200000', callback);
 };
 
 /**


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-26099
- https://jira.appcelerator.org/browse/TIMOB-25867

**Summary:**
- Modified `appc run` to use same intent settings the Android OS uses when tapping on an app.
 * We were missing intent action "MAIN and category "LAUNCHER".
- Fixes issue where pressing "Home" button after `appc run` app launch and then tapping on the app onscreen would not resume the app. Would launch a new splash-screen, but not run the app.
- Fixed regression caused by [TIMOB-25867](https://jira.appcelerator.org/browse/TIMOB-25867) where "Restart Required" dialog would be displayed infinitely on app launch on Pixel XL.

**Test:**
Run the below test on a Pixel XL, Android 4.1 device, and in the Android emulator.
1. Build and run the below code via Appcelerator Studio or via `appc run`.
2. Verify that the app's splash screen is not launched twice. (This ensures that [TIMOB-25867](https://jira.appcelerator.org/browse/TIMOB-25867) is still fixed.)
3. Once launched, press the "Home" button to suspend the app. (Do **NOT** press "Back".)
4. Go to the main app list screen. (Do **NOT** press the "Square" button.)
5. Tap on the app from the list screen.
6. Verify that the app resumes and it is not stuck at the splash screen.

```javascript
var window = Ti.UI.createWindow();
window.add(Ti.UI.createLabel({ text: 'Test' }));
window.open();
```