### PR TITLE
[TIMOB-26126] Android: Update emulator path

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -718,12 +718,13 @@ function findSDK(dir, config, androidPackageJson, callback) {
 
 	var dxJarPath = path.join(dir, 'platform-tools', 'lib', 'dx.jar'),
 		proguardPath = path.join(dir, 'tools', 'proguard', 'lib', 'proguard.jar'),
+		emulatorPath = path.join(dir, 'emulator', 'emulator' + exe),
 		result = {
 			path: dir,
 			executables: {
 				adb:       path.join(dir, 'platform-tools', 'adb' + exe),
 				android:   null, // this tool has been deprecated
-				emulator:  path.join(dir, 'tools', 'emulator' + exe),
+				emulator:  fs.existsSync(emulatorPath) ? emulatorPath : path.join(dir, 'tools', 'emulator' + exe),
 				mksdcard:  path.join(dir, 'tools', 'mksdcard' + exe),
 				zipalign:  path.join(dir, 'tools', 'zipalign' + exe),
 				// Android SDK Tools v21 and older puts aapt and aidl in the platform-tools dir.


### PR DESCRIPTION
- Update `emulator` tooling path, include fallback to old path

###### TEST CASE
- Build and run a project using an x86 emulator
  - `appc run -p android`
- Emulator runs correctly

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26126)