### PR TITLE
[TIMOB-26180] Separate supported and missing tools check. Add check f…

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -451,6 +451,36 @@ exports.detect = function detect(config, opts, finished) {
 			});
 		}
 
+		if (!results.sdk.buildTools.supported) {
+			results.issues.push({
+				id: 'ANDROID_BUILD_TOOLS_NOT_SUPPORTED',
+				type: 'error',
+				message: '\n' + __('Android Build Tools %s are not supported by Titanium', results.sdk.buildTools.version) + '\n'
+					+ __('Current installed Android SDK tools:') + '\n'
+					+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')\n'
+					+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')\n'
+					+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android build tools'] + ')\n\n'
+					+ __('Make sure you have the latest Android SDK Tools, Platform Tools, and Build Tools installed.') + '\n'
+			});
+		}
+
+		if (results.sdk.buildTools.notInstalled) {
+			let configCommand = 'ti config --remove android.buildTools.selectedVersion';
+			if (process.env.APPC_ENV) {
+				configCommand = `appc ${configCommand}`;
+			}
+			results.issues.push({
+				id: 'ANDROID_BUILD_TOOLS_CONFIG_SETTING_NOT_INSTALLED',
+				type: 'error',
+				message: '\n' + __('The selected version of Android SDK Build Tools (%s) are not installed. Please either remove the setting using %s or install it', results.sdk.buildTools.version, configCommand) + '\n'
+					+ __('Current installed Android SDK tools:') + '\n'
+					+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')\n'
+					+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')\n'
+					+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android build tools'] + ')\n\n'
+					+ __('Make sure you have the latest Android SDK Tools, Platform Tools, and Build Tools installed.') + '\n'
+			});
+		}
+
 		// check if we're running Windows and if the sdk path contains ampersands
 		if (process.platform === 'win32' && results.sdk.path.indexOf('&') !== -1) {
 			results.issues.push({
@@ -465,7 +495,7 @@ exports.detect = function detect(config, opts, finished) {
 
 		// check if the sdk is missing any commands
 		var missing = Object.keys(requiredSdkTools).filter(cmd => !results.sdk.executables[cmd]);
-		if (missing.length || !results.sdk.buildTools.supported) {
+		if (missing.length && results.sdk.buildTools.supported) {
 			var dummyPath = path.join(path.resolve('/'), 'path', 'to', 'android-sdk'),
 				msg = '';
 
@@ -832,7 +862,7 @@ function findSDK(dir, config, androidPackageJson, callback) {
 				// build tools don't exist at the given location
 				result.buildTools = {
 					path: path.join(buildToolsDir, ver),
-					supported: false,
+					notInstalled: true,
 					version: ver
 				};
 			}

--- a/lib/android.js
+++ b/lib/android.js
@@ -455,12 +455,8 @@ exports.detect = function detect(config, opts, finished) {
 			results.issues.push({
 				id: 'ANDROID_BUILD_TOOLS_NOT_SUPPORTED',
 				type: 'error',
-				message: '\n' + __('Android Build Tools %s are not supported by Titanium', results.sdk.buildTools.version) + '\n'
-					+ __('Current installed Android SDK tools:') + '\n'
-					+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')\n'
-					+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')\n'
-					+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android build tools'] + ')\n\n'
-					+ __('Make sure you have the latest Android SDK Tools, Platform Tools, and Build Tools installed.') + '\n'
+				message: createAndroidSdkInstallationErrorMessage(__('Android Build Tools %s are not supported by Titanium', results.sdk.buildTools.version))
+
 			});
 		}
 
@@ -468,12 +464,7 @@ exports.detect = function detect(config, opts, finished) {
 			results.issues.push({
 				id: 'ANDROID_BUILD_TOOLS_CONFIG_SETTING_NOT_INSTALLED',
 				type: 'error',
-				message: '\n' + __('The selected version of Android SDK Build Tools (%s) are not installed. Please either remove the setting using %s or install it', results.sdk.buildTools.version, `${commandPrefix} ti config --remove android.buildTools.selectedVersion`) + '\n'
-					+ __('Current installed Android SDK tools:') + '\n'
-					+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')\n'
-					+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')\n'
-					+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android build tools'] + ')\n\n'
-					+ __('Make sure you have the latest Android SDK Tools, Platform Tools, and Build Tools installed.') + '\n'
+				message: createAndroidSdkInstallationErrorMessage(__('The selected version of Android SDK Build Tools (%s) are not installed. Please either remove the setting using %s or install it', results.sdk.buildTools.version, `${commandPrefix} ti config --remove android.buildTools.selectedVersion`))
 			});
 		}
 
@@ -499,12 +490,7 @@ exports.detect = function detect(config, opts, finished) {
 				msg += __n('Missing required Android SDK tool: %%s', 'Missing required Android SDK tools: %%s', missing.length, '__' + missing.join(', ') + '__') + '\n\n';
 			}
 
-			msg += __('The Android SDK located at %s has incomplete or out-of-date packages.', '__' + results.sdk.path + '__') + '\n\n'
-				+ __('Current installed Android SDK tools:') + '\n'
-				+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')\n'
-				+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')\n'
-				+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android build tools'] + ')\n\n'
-				+ __('Make sure you have the latest Android SDK Tools, Platform Tools, and Build Tools installed.') + '\n';
+			msg = createAndroidSdkInstallationErrorMessage(msg);
 
 			if (missing.length) {
 				msg += '\n' + __('You can also specify the exact location of these required tools by running:') + '\n';
@@ -743,6 +729,21 @@ exports.detect = function detect(config, opts, finished) {
 		}
 
 		finalize();
+
+		function createAndroidSdkInstallationErrorMessage(message) {
+			if (!message) {
+				message = '';
+			} else if (message.length > 0) {
+				message += '\n';
+			}
+			message +=
+				__('Current installed Android SDK tools:') + '\n'
+				+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')\n'
+				+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')\n'
+				+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android build tools'] + ')\n\n'
+				+ __('Make sure you have the latest Android SDK Tools, Platform Tools, and Build Tools installed.') + '\n';
+			return message;
+		}
 	});
 };
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -465,14 +465,10 @@ exports.detect = function detect(config, opts, finished) {
 		}
 
 		if (results.sdk.buildTools.notInstalled) {
-			let configCommand = 'ti config --remove android.buildTools.selectedVersion';
-			if (process.env.APPC_ENV) {
-				configCommand = `appc ${configCommand}`;
-			}
 			results.issues.push({
 				id: 'ANDROID_BUILD_TOOLS_CONFIG_SETTING_NOT_INSTALLED',
 				type: 'error',
-				message: '\n' + __('The selected version of Android SDK Build Tools (%s) are not installed. Please either remove the setting using %s or install it', results.sdk.buildTools.version, configCommand) + '\n'
+				message: '\n' + __('The selected version of Android SDK Build Tools (%s) are not installed. Please either remove the setting using %s or install it', results.sdk.buildTools.version, `${commandPrefix} ti config --remove android.buildTools.selectedVersion`) + '\n'
 					+ __('Current installed Android SDK tools:') + '\n'
 					+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')\n'
 					+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')\n'


### PR DESCRIPTION
…or selected version of build tools that is not installed

JIRA: https://jira.appcelerator.org/browse/TIMOB-26180

For the build process errors this requires appcelerator/titanium_mobile/pull/10154

Testing:

- Set a version of build tools that you don't have installed as your selected version using `appc ti config android.buildTools.selectedVersion <version>`, and try building.
	- It should error with a message stating `The selected version of Android SDK Build Tools <version> are not installed.`

- Install a version that is lower than the minimum supported, you might need to select it using `appc ti config android.buildTools.selectedVersion <version>`
	- It should error with something like `Android Build Tools <version> are not supported by Titanium`

- Move the aapt away from the build-tools in the main SDK dir
	- It should error with something like `Missing required Android SDK tool: aapt`

- Try the above with titanium instead of appc,