### PR TITLE
[TIMOB-26280] Fixed bug where process info was stored in this.child w…

### DIFF
--- a/lib/emulators/genymotion.js
+++ b/lib/emulators/genymotion.js
@@ -528,7 +528,7 @@ exports.start = function start(config, emu, opts, callback) {
 
 		opts.logger && opts.logger.info(__('Running: %s', (results.executables.player + ' --vm-name "' + emu.name + '"').cyan));
 
-		var child = this.child = spawn(results.executables.player, [ '--vm-name', emu.name ], emuopts),
+		var child = spawn(results.executables.player, [ '--vm-name', emu.name ], emuopts),
 			device = new EmulatorManager.Emulator();
 
 		device.emulator = {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
[TIMOB-26280] Fixed bug where process info was stored in this.child where 'this' can somehow become undefined.

Fun fact: this bug has been around since Titanium SDK 3.2.0 (4 years ago) and secondly, the AVD code had the same bug and was fixed in June 2018 in 917b0d8cd6d85a7419f52ee769c9611323a29f29.

https://jira.appcelerator.org/browse/TIMOB-26280