### PR TITLE
[TIMOB-26333] Generate source maps

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -230,6 +230,12 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 	}
 
 	if (options.presets.length || options.plugins.length) {
+		// generate and inline source map
+		// we inline the source map as the map cannot be retreived from the device
+		// using the inspector protocol. only parsed .js files can be retreived.
+		if (opts.sourceMap) {
+			options.sourceMaps = 'inline';
+		}
 		// FIXME we can't re-use the ast here, because we traversed it
 		results.contents = babel.transform(contents, options).code;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "0.6.0",
+	"version": "0.6.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
- Generate source maps during development builds or through opt-in `tiapp.xml` property `<source-maps>true</source-maps>`

##### TEST CASE
```JS
class Window {

	constructor () {
		this.view = Ti.UI.createWindow({ backgroundColor: 'gray' });
		this.button = Ti.UI.createButton({ title: 'CLICK' });

		this.view.add(this.button);
	}

	show () {
		this.view.open();
	}

}

new Window().show();
```
- Build an Android Titanium app with `transpile` enabled, debug using Chrome
  - `appc run -p android --debug-host /127.0.0.1:51388`
<img src="https://jira.appcelerator.org/secure/attachment/65472/Screen%20Shot%202018-08-23%20at%2011.28.23%20AM.png" width=500>

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26333)