### PR TITLE
[TIMOB-26621] Retry upon dependency copy failure

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -117,7 +117,7 @@ function getTitaniumExpression(member) {
  */
 function copyPackageAndDependencies(moduleId, destNodeModulesDir, paths = []) {
 	const destPackage = path.join(destNodeModulesDir, moduleId);
-	if (fs.existsSync(destPackage)) {
+	if (fs.existsSync(path.join(destPackage, 'package.json'))) {
 		return; // if the module seems to exist in the destination, just skip it.
 	}
 
@@ -131,10 +131,19 @@ function copyPackageAndDependencies(moduleId, destNodeModulesDir, paths = []) {
 	}
 	const srcPackage = path.dirname(pkgJSONPath);
 	const srcPackageNodeModulesDir = path.join(srcPackage, 'node_modules');
-	fs.copySync(srcPackage, destPackage, {
-		preserveTimestamps: true,
-		filter: src => !src.startsWith(srcPackageNodeModulesDir)
-	});
+	for (let i = 0; i < 3; i++) {
+		fs.copySync(srcPackage, destPackage, {
+			preserveTimestamps: true,
+			filter: src => !src.startsWith(srcPackageNodeModulesDir)
+		});
+
+		// Quickly verify package copied, I've experienced occurences where it does not.
+		// Retry up to three times if it did not copy correctly.
+		if (fs.existsSync(path.join(destPackage, 'package.json'))) {
+			break;
+		}
+	}
+
 	// Now read it's dependencies and recurse on them
 	const packageJSON = fs.readJSONSync(pkgJSONPath);
 	for (const dependency in packageJSON.dependencies) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -960,7 +960,7 @@
 		},
 		"babel-helper-is-nodes-equiv": {
 			"version": "0.0.1",
-			"resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
 			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
 		},
 		"babel-helper-is-void-0": {
@@ -1791,7 +1791,7 @@
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"doctrine": {
 			"version": "1.5.0",
@@ -4539,7 +4539,7 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"ramda": {
 			"version": "0.25.0",
@@ -4669,7 +4669,7 @@
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.13.3",
@@ -4798,7 +4798,7 @@
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha1-gvHsGaQjrB+9CAsLqwa6NuhKeiY=",
+			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -4902,7 +4902,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -4916,7 +4916,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -5152,7 +5152,7 @@
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
- Although rare, `copySync` can fail to copy the dependency correctly
  - Validate `package.json` exists as a quick check to make sure the files have been copied. Otherwise it would only check for the existence of an empty folder and not attempt to copy the dependency again.
  - Retry if the copy fails

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26621)