### PR TITLE
fix: detect installs of android sdk/ndk where brew cask puts them

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -43,7 +43,15 @@ let envCache;
 // Common paths to scan for Android SDK/NDK
 const dirs = process.platform === 'win32'
 	? [ '%SystemDrive%', '%ProgramFiles%', '%ProgramFiles(x86)%', '%CommonProgramFiles%', '~', '%LOCALAPPDATA%/Android' ]
-	: [ '/opt', '/opt/local', '/usr', '/usr/local', '~', '~/Library/Android' ];
+	: [
+		'/opt',
+		'/opt/local',
+		'/usr',
+		'/usr/local',
+		'/usr/local/share', // homebrew cask installs sdk/ndk (symlinks) to /usr/local/share/android-(sdk|ndk)
+		'~',
+		'~/Library/Android' // Android Studio installs the NDK to ~/Library/Android/Sdk/ndk-bundle
+	];
 
 // need to find the android module and its package.json
 let androidPackageJson = {};


### PR DESCRIPTION
In setting up my new work laptop, I'm trying to streamline the process to get set up - including just installing what I need via home-brew whenever possible.

I'm working on a bash setup script for our usage internally and possibly also as an eventual "installer" for users: https://github.com/sgtcoolguy/macos-setup

Anyways, homebrew cask can install Android SDK/NDK, but it puts them in a location e don't automatically detect: `/usr/local/share/android-sdk` and `/usr/local/share/android-ndk`