### PR TITLE
fix: do not include web polyfills

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -241,7 +241,12 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 	if (opts.transpile) {
 		options.plugins.push(require.resolve('./babel-plugins/global-this'));
 		options.plugins.push(require.resolve('@babel/plugin-transform-async-to-generator'));
-		options.presets.push([ env, { targets: opts.targets, useBuiltIns: 'usage' } ]);
+		options.presets.push([ env, {
+			targets: opts.targets,
+			useBuiltIns: 'usage',
+			// DO NOT include web polyfills!
+			exclude: [ 'web.dom.iterable', 'web.immediate', 'web.timers' ]
+		} ]);
 
 		// install polyfill
 		if (opts.resourcesDir) {

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -40,5 +40,11 @@ describe('jsanalyze', function () {
 			fs.existsSync(path.join(tmpDir, 'node_modules', 'core-js')).should.eql.true;
 			fs.existsSync(path.join(tmpDir, 'node_modules', 'regenerator-runtime')).should.eql.true;
 		});
+
+		it('does not inject web polyfills', function () {
+			const results = jsanalyze.analyzeJs('Object.getOwnPropertyNames({}).forEach(function (name) {properties[name] = this[name];});', { transpile: true, targets: { ios: 8 }, resourcesDir: tmpDir });
+			// DOES NOT CONTAIN require of web.dom.iterable!
+			results.contents.should.eql('Object.getOwnPropertyNames({}).forEach(function (name) {properties[name] = this[name];});');
+		});
 	});
 });

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -32,6 +32,8 @@ describe('jsanalyze', function () {
 		});
 
 		it('handles polyfilling implicitly under the hood', function () {
+			this.timeout(5000);
+			this.slow(2000);
 			const results = jsanalyze.analyzeJs('const result = Array.from(1, 2, 3);', { transpile: true, resourcesDir: tmpDir });
 			results.contents.should.eql('require("core-js/modules/es6.string.iterator");require("core-js/modules/es6.array.from");var result = Array.from(1, 2, 3);');
 			// Verify that core-js, @babel/polyfill, regenerator-runtime are copied over!


### PR DESCRIPTION
Relates to https://jira.appcelerator.org/browse/TIMOB-26742

This excludes web specific polyfills from being injected into user apps on transpilation. I noticed that web.dom.iterable was injected pretty frequently and is entirely irrelevant to Titanium apps.