### PR TITLE
fix: fall back to looser parsing if necessary

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -170,8 +170,18 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 
 	// parse the js file
 	let ast;
+	const parserOpts = {
+		sourceType: 'unambiguous',
+		filename: opts.filename
+	};
 	try {
-		ast = babylon.parse(contents, { filename: opts.filename, sourceType: 'unambiguous' });
+		try {
+			ast = babylon.parse(contents, parserOpts);
+		} catch (err) {
+			// fall back to much looser parsing
+			parserOpts.allowReturnOutsideFunction = true;
+			ast = babylon.parse(contents, parserOpts);
+		}
 	} catch (ex) {
 		var errmsg = [ __('Failed to parse %s', opts.filename) ];
 		if (ex.line) {
@@ -232,9 +242,7 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 		plugins: [
 			[ require.resolve('./babel-plugins/global-scope'), { logger: opts.logger } ]
 		],
-		parserOpts: {
-			sourceType: 'unambiguous'
-		}
+		parserOpts
 	};
 
 	// transpile


### PR DESCRIPTION
This is a simple fix: if parsing a JS file fails, fall back to trying to parse as a script explicitly and allowing returns outside functions.

The came up from trying to use the official mocha package in our test suite. The build of the app fails because `mkdirp` has a `bin\cmd.js` file using a return "globally" which is allowed under Node.

I think there's a larger discussion to be had as to whether we should be parsing/transpiling/minifying 3rd party node_modules, but for now I think having a fall back like this makes some sense.