### PR TITLE
 refactor: gather Ti API usage inline with rest of babel plugins

### DIFF
--- a/lib/babel-plugins/ti-api.js
+++ b/lib/babel-plugins/ti-api.js
@@ -1,0 +1,103 @@
+'use strict';
+
+/**
+ * Keeps track of the Titanium APIs used globally (across the whoel build, so implicitly "per-project").
+ */
+const apiUsage = {};
+
+/**
+ * Keeps track of the Titanium APIs used for a given files.
+ */
+const symbols = new Set();
+
+/**
+ * The actual Babel plugin definition. This plugin does not transform anything in the AST/code,
+ * but instead tracks usage of our Titanium APIs for our own analytics as well as to help
+ * pare production builds down to only include the Titanium APIs/modules/frameworks used by the app.
+ * @param {object} _ref object containing references for babel plugins to make use of
+ * @param {object} _ref.types instance of @babel/types
+ * @returns {object} the instance of the plugin used by Babel during transforms
+ */
+function plugin(_ref) {
+	const types = _ref.types;
+	/**
+	 * Returns the name of identifiers, value of string literals, or `'obj.value'` of member expressions.
+	 * @param {object} node an AST node from Babel
+	 * @returns {string|null} value of a given node.
+	 */
+	function getMemberValue(node) {
+		if (types.isIdentifier(node)) {
+			return node.name;
+		}
+
+		if (types.isStringLiteral(node)) {
+			return node.value;
+		}
+
+		if (!types.isMemberExpression(node)) {
+			return null;
+		}
+
+		if (node.computed && !types.isStringLiteral(node.property)) {
+			return null;
+		}
+
+		const objVal = getMemberValue(node.object);
+		if (objVal === null) {
+			return null;
+		}
+
+		const propVal = getMemberValue(node.property);
+		if (propVal === null) {
+			return null;
+		}
+		return objVal + '.' + propVal;
+	}
+
+	/**
+	 * Given a MemberExpression node, returns the expression as a String if possible
+	 * (if composed of literals/identifiers)
+	 * @param {object} member an AST node (MemberExpression) from Babel
+	 * @returns {string|null}
+	 */
+	function getTitaniumExpression(member) {
+		const value = getMemberValue(member);
+		if (value === null) {
+			return null;
+		}
+
+		const tiNodeRegExp = /^Ti(tanium)?/;
+		if (tiNodeRegExp.test(value)) {
+			// Normalize 'Ti.*' to 'Titanium.*'
+			if (value.startsWith('Ti.')) {
+				return `Titanium.${value.substring(3)}`;
+			}
+			return value;
+		}
+		return null;
+	}
+	return {
+		pre() {
+			symbols.clear(); // wipe symbols before each AST, gather these "per-file"
+		},
+		visitor: {
+			MemberExpression(path, state) {
+				const memberExpr = getTitaniumExpression(path.node);
+				if (memberExpr) {
+					symbols.add(memberExpr.substring(9)); // Drop leading 'Titanium.'
+					if (!state.opts.skipStats) {
+						if (apiUsage[memberExpr] === undefined) {
+							apiUsage[memberExpr] = 1;
+						} else {
+							apiUsage[memberExpr]++;
+						}
+					}
+				}
+			}
+		}
+	};
+}
+plugin.apiUsage = apiUsage; // expose the apiUsage
+plugin.symbols = symbols; // expose the symbol usage
+
+module.exports = plugin;

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -19,13 +19,10 @@ const path = require('path');
 const DOMParser = require('xmldom').DOMParser;
 const babel = require('@babel/core');
 const babylon = require('@babel/parser');
-const types = require('@babel/types');
-const traverse = require('@babel/traverse').default;
 const minify = require('babel-preset-minify');
 const env = require('@babel/preset-env');
+const apiTracker = require('./babel-plugins/ti-api');
 const __ = appc.i18n(__dirname).__;
-
-let apiUsage = {};
 
 /**
  * Returns an object with the Titanium API usage statistics.
@@ -33,7 +30,7 @@ let apiUsage = {};
  * @returns {Object} The API usage stats
  */
 exports.getAPIUsage = function getAPIUsage() {
-	return apiUsage;
+	return apiTracker.apiUsage;
 };
 
 /**
@@ -46,59 +43,10 @@ exports.getAPIUsage = function getAPIUsage() {
  * @returns {Object} An object containing symbols and minified JavaScript
  * @throws {Error} An error if unable to parse the JavaScript
  */
-exports.analyzeJsFile = function analyzeJsFile(file, opts) {
-	opts || (opts = {});
+exports.analyzeJsFile = function analyzeJsFile(file, opts = {}) {
 	opts.filename = file;
 	return exports.analyzeJs(fs.readFileSync(file).toString(), opts);
 };
-
-// Need to look for MemberExpressions, expand them out to full name
-
-function getMemberValue(node) {
-	if (types.isIdentifier(node)) {
-		return node.name;
-	}
-
-	if (types.isStringLiteral(node)) {
-		return node.value;
-	}
-
-	if (!types.isMemberExpression(node)) {
-		return null;
-	}
-
-	if (node.computed && !types.isStringLiteral(node.property)) {
-		return null;
-	}
-
-	const objVal = getMemberValue(node.object);
-	if (objVal === null) {
-		return null;
-	}
-
-	const propVal = getMemberValue(node.property);
-	if (propVal === null) {
-		return null;
-	}
-	return objVal + '.' + propVal;
-}
-
-function getTitaniumExpression(member) {
-	const value = getMemberValue(member);
-	if (value === null) {
-		return null;
-	}
-
-	const tiNodeRegExp = /^Ti(tanium)?/;
-	if (tiNodeRegExp.test(value)) {
-		// if value.startsWith('Ti.'), replace with 'Titanium.'
-		if (value.indexOf('Ti.') === 0) {
-			return 'Titanium.' + value.substring(3);
-		}
-		return value;
-	}
-	return null;
-}
 
 /**
  * Given an npm module id, this will copy it and it's dependencies to a
@@ -164,8 +112,7 @@ function copyPackageAndDependencies(moduleId, destNodeModulesDir, paths = []) {
  * @returns {Object} An object containing symbols and minified JavaScript
  * @throws {Error} An error if unable to parse the JavaScript
  */
-exports.analyzeJs = function analyzeJs(contents, opts) {
-	opts || (opts = {});
+exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 	opts.plugins || (opts.plugins = []);
 
 	// parse the js file
@@ -173,7 +120,7 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 	try {
 		ast = babylon.parse(contents, { filename: opts.filename, sourceType: 'unambiguous' });
 	} catch (ex) {
-		var errmsg = [ __('Failed to parse %s', opts.filename) ];
+		const errmsg = [ __('Failed to parse %s', opts.filename) ];
 		if (ex.line) {
 			errmsg.push(__('%s [line %s, column %s]', ex.message, ex.line, ex.col));
 		} else {
@@ -199,30 +146,10 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 		throw new Error(errmsg.join('\n'));
 	}
 
-	// find all of the titanium symbols
-	const symbols = {};
-	traverse(ast, {
-		MemberExpression: {
-			enter: function (path) {
-				var memberExpr = getTitaniumExpression(path.node);
-				if (memberExpr) {
-					symbols[memberExpr.substring(9)] = 1; // Drop leading 'Titanium.'
-					if (!opts.skipStats) {
-						if (apiUsage[memberExpr] === undefined) {
-							apiUsage[memberExpr] = 1;
-						} else {
-							apiUsage[memberExpr]++;
-						}
-					}
-				}
-			}
-		}
-	});
-
 	const results = {
 		original: contents,
 		contents: contents,
-		symbols: Object.keys(symbols) // convert the object of symbol names to an array of symbol names
+		symbols: [] // apiTracker plugin will gather these!
 	};
 
 	const options = {
@@ -230,7 +157,8 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 		retainLines: true,
 		presets: [],
 		plugins: [
-			[ require.resolve('./babel-plugins/global-scope'), { logger: opts.logger } ]
+			[ require.resolve('./babel-plugins/global-scope'), { logger: opts.logger } ],
+			[ apiTracker, { skipStats: opts.skipStats } ] // track our API usage no matter what
 		],
 		parserOpts: {
 			sourceType: 'unambiguous'
@@ -289,8 +217,8 @@ exports.analyzeJs = function analyzeJs(contents, opts) {
 		options.sourceMaps = 'inline';
 	}
 
-	// FIXME we can't re-use the ast here, because we traversed it
-	results.contents = babel.transformSync(contents, options).code;
+	results.contents = babel.transformFromAstSync(ast, contents, options).code;
+	results.symbols = Array.from(apiTracker.symbols.values()); // convert Set values to Array
 
 	return results;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5155,6 +5155,7 @@
 					"version": "0.1.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -5472,7 +5473,8 @@
 				"is-buffer": {
 					"version": "1.1.6",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
@@ -5553,6 +5555,7 @@
 					"version": "3.2.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -5598,7 +5601,8 @@
 				"longest": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
@@ -5855,7 +5859,8 @@
 				"repeat-string": {
 					"version": "1.6.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"require-directory": {
 					"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
 		"@babel/plugin-transform-property-literals": "^7.0.0",
 		"@babel/polyfill": "^7.0.0",
 		"@babel/preset-env": "^7.0.0",
-		"@babel/traverse": "^7.0.0",
-		"@babel/types": "^7.0.0",
 		"async": "^2.6.1",
 		"babel-preset-minify": "^0.5.0",
 		"colors": "^1.3.2",
@@ -80,10 +78,10 @@
 	},
 	"nyc": {
 		"check-coverage": true,
-		"lines": 56,
+		"lines": 55,
 		"statements": 55,
-		"functions": 60,
-		"branches": 40,
+		"functions": 59,
+		"branches": 39,
 		"exclude": [
 			"tests/**/*.js",
 			"locales/**/*.js"

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -26,6 +26,18 @@ describe('jsanalyze', function () {
 			results.symbols.should.eql([ 'API.info', 'API' ]);
 		});
 
+		it('tracks Ti API usage across multiple calls', function () {
+			const results = jsanalyze.analyzeJs('Ti.UI.createView({});', {});
+			results.symbols.should.eql([ 'UI.createView', 'UI' ]); // symbols only includes from this call
+			// includes symbols from this test and the one above!
+			jsanalyze.getAPIUsage().should.eql({
+				'Titanium.API.info': 1,
+				'Titanium.API': 1,
+				'Titanium.UI.createView': 1,
+				'Titanium.UI': 1
+			});
+		});
+
 		it('converts global "this" references into "global" references when transpiling', function () {
 			const results = jsanalyze.analyzeJs('this.myGlobalMethod = function() {};', { transpile: true });
 			results.contents.should.eql('global.myGlobalMethod = function () {};');

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -21,6 +21,11 @@ describe('jsanalyze', function () {
 			fs.remove(tmpDir, finish);
 		});
 
+		it('tracks Ti API symbols', function () {
+			const results = jsanalyze.analyzeJs('Ti.API.info("yeah");', {});
+			results.symbols.should.eql([ 'API.info', 'API' ]);
+		});
+
 		it('converts global "this" references into "global" references when transpiling', function () {
 			const results = jsanalyze.analyzeJs('this.myGlobalMethod = function() {};', { transpile: true });
 			results.contents.should.eql('global.myGlobalMethod = function () {};');


### PR DESCRIPTION
This avoids the need to explicilty require @babel/types and @babel/traverse as direct dependencies; as well as avoids needing to traverse the AST twice. This should allow for a faster CLI build of apps.

Before we'd parse the JS file, then traverse the AST once just to scan for Ti API usage- then moving on to setting up babel presets/plugins for transpile/minify/etc and parsing the code and traversing the AST *again*! So this is a fairly "simple" change that should speed up the build by a noticeable amount (hopefully).