### PR TITLE
Polyfill removal

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -15,7 +15,6 @@
 
 const appc = require('node-appc');
 const fs = require('fs-extra');
-const path = require('path');
 const DOMParser = require('xmldom').DOMParser;
 const babel = require('@babel/core');
 const babylon = require('@babel/parser');
@@ -47,57 +46,6 @@ exports.analyzeJsFile = function analyzeJsFile(file, opts = {}) {
 	opts.filename = file;
 	return exports.analyzeJs(fs.readFileSync(file).toString(), opts);
 };
-
-/**
- * Given an npm module id, this will copy it and it's dependencies to a
- * destination "node_modules" folder.
- * Note that all of the packages are copied to the top-level of "node_modules",
- * not nested!
- * Also, to shortcut the logic, if the original package has been copied to the
- * destination we will *not* attempt to read it's dependencies and ensure those
- * are copied as well! So if the modules version changes or something goes
- * haywire and the copies aren't full finished due to a failure, the only way to
- * get right is to clean the destination "node_modules" dir before rebuilding.
- *
- * @param  {String} moduleId           The npm package/module to copy (along with it's dependencies)
- * @param  {String} destNodeModulesDir path to the destination "node_mdoules" folder
- * @param  {Array}  [paths=[]]         Array of additional paths to pass to require.resolve() (in addition to those from require.resolve.paths(moduleId))
- */
-function copyPackageAndDependencies(moduleId, destNodeModulesDir, paths = []) {
-	const destPackage = path.join(destNodeModulesDir, moduleId);
-	if (fs.existsSync(path.join(destPackage, 'package.json'))) {
-		return; // if the module seems to exist in the destination, just skip it.
-	}
-
-	// copy the dependency's folder over
-	let pkgJSONPath;
-	if (require.resolve.paths) {
-		const thePaths = require.resolve.paths(moduleId);
-		pkgJSONPath = require.resolve(path.join(moduleId, 'package.json'), { paths: thePaths.concat(paths) });
-	} else {
-		pkgJSONPath = require.resolve(path.join(moduleId, 'package.json'));
-	}
-	const srcPackage = path.dirname(pkgJSONPath);
-	const srcPackageNodeModulesDir = path.join(srcPackage, 'node_modules');
-	for (let i = 0; i < 3; i++) {
-		fs.copySync(srcPackage, destPackage, {
-			preserveTimestamps: true,
-			filter: src => !src.startsWith(srcPackageNodeModulesDir)
-		});
-
-		// Quickly verify package copied, I've experienced occurences where it does not.
-		// Retry up to three times if it did not copy correctly.
-		if (fs.existsSync(path.join(destPackage, 'package.json'))) {
-			break;
-		}
-	}
-
-	// Now read it's dependencies and recurse on them
-	const packageJSON = fs.readJSONSync(pkgJSONPath);
-	for (const dependency in packageJSON.dependencies) {
-		copyPackageAndDependencies(dependency, destNodeModulesDir, [ srcPackageNodeModulesDir ]);
-	}
-}
 
 /**
  * Analyzes a string containing JavaScript for all Titanium API symbols.
@@ -177,25 +125,7 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 	if (opts.transpile) {
 		options.plugins.push(require.resolve('./babel-plugins/global-this'));
 		options.plugins.push(require.resolve('@babel/plugin-transform-async-to-generator'));
-		options.presets.push([ env, {
-			targets: opts.targets,
-			useBuiltIns: 'usage',
-			// DO NOT include web polyfills!
-			exclude: [ 'web.dom.iterable', 'web.immediate', 'web.timers' ]
-		} ]);
-
-		// install polyfill
-		if (opts.resourcesDir) {
-			const modulesDir = path.join(opts.resourcesDir, 'node_modules');
-
-			// make sure our 'node_modules' directory exists
-			if (!fs.existsSync(modulesDir)) {
-				fs.mkdirSync(modulesDir);
-			}
-
-			// copy over polyfill and its dependencies
-			copyPackageAndDependencies('@babel/polyfill', modulesDir);
-		}
+		options.presets.push([ env, { targets: opts.targets } ]);
 	}
 
 	// minify

--- a/package-lock.json
+++ b/package-lock.json
@@ -620,15 +620,6 @@
 				"regexpu-core": "^4.1.3"
 			}
 		},
-		"@babel/polyfill": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
-			"integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
-			"requires": {
-				"core-js": "^2.5.7",
-				"regenerator-runtime": "^0.11.1"
-			}
-		},
 		"@babel/preset-env": {
 			"version": "7.1.5",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.5.tgz",
@@ -2013,7 +2004,8 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -6586,11 +6578,6 @@
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.13.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"@babel/core": "^7.0.0",
 		"@babel/parser": "^7.0.0",
 		"@babel/plugin-transform-property-literals": "^7.0.0",
-		"@babel/polyfill": "^7.0.0",
 		"@babel/preset-env": "^7.0.0",
 		"async": "^2.6.1",
 		"babel-preset-minify": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"

--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
 	},
 	"nyc": {
 		"check-coverage": true,
-		"lines": 55,
-		"statements": 55,
-		"functions": 59,
-		"branches": 39,
+		"lines": 56,
+		"statements": 56,
+		"functions": 60,
+		"branches": 40,
 		"exclude": [
 			"tests/**/*.js",
 			"locales/**/*.js"

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -47,23 +47,5 @@ describe('jsanalyze', function () {
 			const results = jsanalyze.analyzeJs('var myGlobalMethod = function() { return this; };', { transpile: true });
 			results.contents.should.eql('var myGlobalMethod = function myGlobalMethod() {return this;};');
 		});
-
-		it('handles polyfilling implicitly under the hood', function () {
-			this.timeout(5000);
-			this.slow(2000);
-			const results = jsanalyze.analyzeJs('const result = Array.from(1, 2, 3);', { transpile: true, resourcesDir: tmpDir });
-			results.contents.should.eql('require("core-js/modules/es6.string.iterator");require("core-js/modules/es6.array.from");var result = Array.from(1, 2, 3);');
-			// Verify that core-js, @babel/polyfill, regenerator-runtime are copied over!
-			fs.existsSync(path.join(tmpDir, 'node_modules', '@babel', 'polyfill')).should.eql.true;
-			fs.existsSync(path.join(tmpDir, 'node_modules', '@babel', 'polyfill', 'node_modules', 'core-js')).should.eql.false;
-			fs.existsSync(path.join(tmpDir, 'node_modules', 'core-js')).should.eql.true;
-			fs.existsSync(path.join(tmpDir, 'node_modules', 'regenerator-runtime')).should.eql.true;
-		});
-
-		it('does not inject web polyfills', function () {
-			const results = jsanalyze.analyzeJs('Object.getOwnPropertyNames({}).forEach(function (name) {properties[name] = this[name];});', { transpile: true, targets: { ios: 8 }, resourcesDir: tmpDir });
-			// DOES NOT CONTAIN require of web.dom.iterable!
-			results.contents.should.eql('Object.getOwnPropertyNames({}).forEach(function (name) {properties[name] = this[name];});');
-		});
 	});
 });


### PR DESCRIPTION
Relates to appcelerator/titanium_mobile#10567

We may need to move polyfilling up to the SDK build process itself to support doing things like async functions in our bootstrap code. (Specifically when I'm trying to add support for things like Node's `assert.rejects()`)

If we do so, polyfilling during the user app build based on usage is no longer necessary.

This PR is meant to remove polyfilling from node-titanium-sdk altogether and would be merged/coordinated with the PR in the SDK that did the polyfilling during SDK build itself instead.