### PR TITLE
Remove async transform explicit plugin listing

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -124,7 +124,6 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 	// transpile
 	if (opts.transpile) {
 		options.plugins.push(require.resolve('./babel-plugins/global-this'));
-		options.plugins.push(require.resolve('@babel/plugin-transform-async-to-generator'));
 		options.presets.push([ env, { targets: opts.targets } ]);
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -47,5 +47,10 @@ describe('jsanalyze', function () {
 			const results = jsanalyze.analyzeJs('var myGlobalMethod = function() { return this; };', { transpile: true });
 			results.contents.should.eql('var myGlobalMethod = function myGlobalMethod() {return this;};');
 		});
+
+		it('transpile and minify works and transforms async/await when targeting old iOS', function () {
+			const results = jsanalyze.analyzeJs('async function other() { return 1; }; async function first() { const result = await other(); return result + 3; };', { transpile: true, minify: true, targets: { ios: 8 } });
+			results.contents.should.eql('function asyncGeneratorStep(gen,resolve,reject,_next,_throw,key,arg){try{var info=gen[key](arg),value=info.value}catch(error){return void reject(error)}info.done?resolve(value):Promise.resolve(value).then(_next,_throw)}function _asyncToGenerator(fn){return function(){var self=this,args=arguments;return new Promise(function(resolve,reject){function _next(value){asyncGeneratorStep(gen,resolve,reject,_next,_throw,"next",value)}function _throw(err){asyncGeneratorStep(gen,resolve,reject,_next,_throw,"throw",err)}var gen=fn.apply(self,args);_next(void 0)})}}function other(){return _other.apply(this,arguments)}function _other(){return _other=_asyncToGenerator(regeneratorRuntime.mark(function _callee(){return regeneratorRuntime.wrap(function _callee$(_context){for(;1;)switch(_context.prev=_context.next){case 0:return _context.abrupt("return",1);case 1:case"end":return _context.stop();}},_callee,this)})),_other.apply(this,arguments)};function first(){return _first.apply(this,arguments)}function _first(){return _first=_asyncToGenerator(regeneratorRuntime.mark(function _callee2(){var result;return regeneratorRuntime.wrap(function _callee2$(_context2){for(;1;)switch(_context2.prev=_context2.next){case 0:return _context2.next=2,other();case 2:return result=_context2.sent,_context2.abrupt("return",result+3);case 4:case"end":return _context2.stop();}},_callee2,this)})),_first.apply(this,arguments)};');
+		});
 	});
 });


### PR DESCRIPTION
This is causing master builds to fail suddenly on the SDK. It appears to be from a. fluke in how the node_modules folders are getting constructed that this particular plugin lives underneath preset-env and resolution from our jsanalyze.js file fails. In a local test, it appears we don't need to manually add this plugin to the list and it just gets run when the targeted platform needs it (via preset-env).