### PR TITLE
[TIMOB-26919] Android: Support d8 dexer.

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -770,6 +770,7 @@ function findSDK(dir, config, androidPackageJson, callback) {
 	}
 
 	const dxJarPath = path.join(dir, 'platform-tools', 'lib', 'dx.jar'),
+		d8JarPath = path.join(dir, 'platform-tools', 'lib', 'd8.jar'),
 		proguardPath = path.join(dir, 'tools', 'proguard', 'lib', 'proguard.jar'),
 		emulatorPath = path.join(dir, 'emulator', 'emulator' + exe),
 		result = {
@@ -785,9 +786,11 @@ function findSDK(dir, config, androidPackageJson, callback) {
 				aapt:      path.join(dir, 'platform-tools', 'aapt' + exe),
 				aidl:      path.join(dir, 'platform-tools', 'aidl' + exe),
 				dx:        path.join(dir, 'platform-tools', 'dx' + bat),
+				d8:        path.join(dir, 'platform-tools', 'd8' + bat),
 				apksigner: null
 			},
 			dx: fs.existsSync(dxJarPath) ? dxJarPath : null,
+			d8: fs.existsSync(d8JarPath) ? d8JarPath : null,
 			proguard: fs.existsSync(proguardPath) ? proguardPath : null,
 			tools: {
 				path: null,
@@ -861,6 +864,8 @@ function findSDK(dir, config, androidPackageJson, callback) {
 					fs.existsSync(file = path.join(buildToolsDir, ver, 'apksigner' + bat)) && (result.executables.apksigner = file);
 					fs.existsSync(file = path.join(buildToolsDir, ver, 'dx' + bat)) && (result.executables.dx = file);
 					fs.existsSync(file = path.join(buildToolsDir, ver, 'lib', 'dx.jar')) && (result.dx = file);
+					fs.existsSync(file = path.join(buildToolsDir, ver, 'd8' + bat)) && (result.executables.d8 = file);
+					fs.existsSync(file = path.join(buildToolsDir, ver, 'lib', 'd8.jar')) && (result.d8 = file);
 					fs.existsSync(file = path.join(buildToolsDir, ver, 'zipalign' + exe)) && (result.executables.zipalign = file);
 				}
 			} else {

--- a/lib/tiappxml.js
+++ b/lib/tiappxml.js
@@ -224,6 +224,10 @@ function toXml(dom, parent, name, value) {
 				dom.create('tool-api-level', { nodeValue: value['tool-api-level'] }, node);
 			}
 
+			if (value.hasOwnProperty('enableDesugar')) {
+				dom.create('enableDesugar', { nodeValue: value['enableDesugar'] }, node);
+			}
+
 			if (value.hasOwnProperty('abi')) {
 				dom.create('abi', { nodeValue: Array.isArray(value.abi) ? value.abi.join(',') : value.abi }, node);
 			}
@@ -623,6 +627,7 @@ function toJS(obj, doc) {
 								break;
 
 							case 'tool-api-level':
+							case 'enableDesugar':
 								android[elem.tagName] = xml.getValue(elem);
 								break;
 


### PR DESCRIPTION
This PR don't really provide `d8` support, but exports two additional properties available inside `AndroidBuilder` methods:
* `this.androidInfo.sdk.d8` - path to `d8` jar
* `this.tiapp.android.enableDesugar` - value of property in tiapp.xml:
```xml
<ti:app xmlns:ti="http://ti.appcelerator.org">
  ...
  <android>
    <manifest>...</manifest>
    <enableDesugar>true</enableDesugar>
  </android>
  ...
</ti>
```

P.S. [Origin](https://developer.android.com/studio/write/java8-support#disable) of `enableDesugar` property name.
