### PR TITLE
source mapping tweaks

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -150,11 +150,11 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 		options.plugins.push.apply(options.plugins, opts.plugins);
 	}
 
-	let sourceFileName = opts.filename; // what we will report in the special sourceURL comment
-	// generate an inline source map
-	// we inline the source map because iOS web inspector can't access the original source file/map
-	// and we may not have access to the original file once on device
+	let sourceFileName = opts.filename; // sued to poitn to correct original source in sources/sourceRoot of final source map
+	// generate a source map
 	if (opts.sourceMap) {
+		// we manage the source maps ourselves rather than just choose 'inline'
+		// because we need to do some massaging
 		options.sourceMaps = true;
 
 		// If the original file already has a source map, load it so we can pass it along to babel
@@ -190,30 +190,28 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 			// Strip sources to base names so they get matched up properly in debugger script listing
 			existingMap.sources = existingMap.sources.map(s => path.basename(s));
 
-			options.inputSourceMap = existingMap; // ok, we've mangled the source map enough for babel to consume it
+			// ok, we've mangled the source map enough for babel to consume it
+			options.inputSourceMap = existingMap;
 		}
-		// DO NOT set sourceFileName to real source file path, it will break iOS,
-		// and while Android works (and then we can eliminate sourcesContent from map)
-		// it leads to an odd folder listing split between the generated file and original file
-		// Instead, we set the relative filename
-
-		// It looks like the source of iOS issues is when the sourceFileName is not an *exact* match for the basename of the file
-		// Why iOS/Safari shows scripts only by their basename instead of the relative path in-app, or the absolute url we give it, I don't know
 	}
 	const transformed = babel.transformFromAstSync(ast, contents, options);
 	results.contents = transformed.code;
+
 	if (opts.sourceMap) {
 		// Drop the original sourceMappingURL comment (for alloy files)
 		results.contents = results.contents.replace(SOURCE_MAPPING_URL_REGEXP, '');
-		// DO NOT DELETE transformed.map.sourcesContent! Because we don't point to the real absolute filepath of the source file
-		// the JS debugger *cannot* load the contents itself!
-		// TODO: Should we strip/avoid injecting sourcesContent on production builds?
+		// Point the sourceRoot at the original dir (so the full filepath of the original source can be gleaned from sources/sourceRoot combo)
+		transformed.map.sourceRoot = path.dirname(sourceFileName);
+		// Android / Chrome DevTools is sane and can load the source from disk
+		// so we can ditch inlining the original source there (I'm looking at you Safari/WebInspector!)
+		if (opts.platform === 'android') {
+			delete transformed.map.sourcesContent;
+		}
+
 		// Do our own inlined source map so we can have control over the map object that is written!
 		const base64Contents = Buffer.from(JSON.stringify(transformed.map)).toString('base64');
-		// ensure posix style file separators, turn into file:// URI, encode as URI
-		const sourceURL = encodeURI(`file://${sourceFileName.replace(/\\/g, '/')}`);
 		// NOTE: We MUST append a \n or else iOS will break, because it injects a ';' after the original file contents when doing it's require() impl
-		results.contents += `\n//# sourceURL=${sourceURL}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Contents}\n`;
+		results.contents += `\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Contents}\n`;
 	}
 	results.symbols = Array.from(apiTracker.symbols.values()); // convert Set values to Array
 

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -21,6 +21,9 @@ const babylon = require('@babel/parser');
 const minify = require('babel-preset-minify');
 const env = require('@babel/preset-env');
 const apiTracker = require('./babel-plugins/ti-api');
+const path = require('path');
+
+const SOURCE_MAPPING_URL_REGEXP = /\/\/#[ \t]+sourceMappingURL=([^\s'"`]+?)[ \t]*$/mg;
 const __ = appc.i18n(__dirname).__;
 
 /**
@@ -147,11 +150,48 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 		options.plugins.push.apply(options.plugins, opts.plugins);
 	}
 
+	let sourceFileName = opts.filename; // what we will report in the special sourceURL comment
 	// generate an inline source map
 	// we inline the source map because iOS web inspector can't access the original source file/map
 	// and we may not have access to the original file once on device
 	if (opts.sourceMap) {
 		options.sourceMaps = true;
+
+		// If the original file already has a source map, load it so we can pass it along to babel
+		const mapResults = findSourceMap(contents, opts.filename);
+		if (mapResults) {
+			const existingMap = mapResults.map;
+			// location we should try and resolve sources against (after sourceRoot)
+			// this may be a pointer to the external .map file, or point to the source file where the map was inlined
+			// Note that the spec is pretty ambiguous about this (relative to the SourceMap) and I think Safari may try relative to
+			// the original sourceURL too?
+			const mapFile = mapResults.filepath;
+
+			// Choose last entry in 'sources' as the one we'll report as original sourceURL
+			sourceFileName = existingMap.sources[existingMap.sources.length - 1];
+
+			// If the existing source map has a source root, we need to combine it with source path to get full filepath
+			if (existingMap.sourceRoot) {
+				// source root may be a filepath, file URI or URL. We assume file URI/path here
+				if (existingMap.sourceRoot.startsWith('file://')) {
+					existingMap.sourceRoot = existingMap.sourceRoot.slice(7);
+				}
+				sourceFileName = path.resolve(existingMap.sourceRoot, sourceFileName);
+				delete existingMap.sourceRoot; // drop the sourceRoot here so it doesn't get passed along, may break iOS/Web Inspector
+			}
+			// if sourceFilename is still not absolute, resolve relative to map file
+			sourceFileName = path.resolve(path.dirname(mapFile), sourceFileName);
+
+			delete existingMap.file; // ignore the intermediate filename, don't pass it along as we'll use our own name
+
+			// Inject sourcesContent of original file contents into the source map
+			existingMap.sourcesContent = [ fs.readFileSync(sourceFileName, 'utf-8') ];
+
+			// Strip sources to base names so they get matched up properly in debugger script listing
+			existingMap.sources = existingMap.sources.map(s => path.basename(s));
+
+			options.inputSourceMap = existingMap; // ok, we've mangled the source map enough for babel to consume it
+		}
 		// DO NOT set sourceFileName to real source file path, it will break iOS,
 		// and while Android works (and then we can eliminate sourcesContent from map)
 		// it leads to an odd folder listing split between the generated file and original file
@@ -163,12 +203,15 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 	const transformed = babel.transformFromAstSync(ast, contents, options);
 	results.contents = transformed.code;
 	if (opts.sourceMap) {
+		// Drop the original sourceMappingURL comment (for alloy files)
+		results.contents = results.contents.replace(SOURCE_MAPPING_URL_REGEXP, '');
 		// DO NOT DELETE transformed.map.sourcesContent! Because we don't point to the real absolute filepath of the source file
 		// the JS debugger *cannot* load the contents itself!
+		// TODO: Should we strip/avoid injecting sourcesContent on production builds?
 		// Do our own inlined source map so we can have control over the map object that is written!
 		const base64Contents = Buffer.from(JSON.stringify(transformed.map)).toString('base64');
 		// ensure posix style file separators, turn into file:// URI, encode as URI
-		const sourceURL = encodeURI(`file://${opts.filename.replace(/\\/g, '/')}`);
+		const sourceURL = encodeURI(`file://${sourceFileName.replace(/\\/g, '/')}`);
 		// NOTE: We MUST append a \n or else iOS will break, because it injects a ';' after the original file contents when doing it's require() impl
 		results.contents += `\n//# sourceURL=${sourceURL}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Contents}\n`;
 	}
@@ -176,6 +219,43 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 
 	return results;
 };
+
+/**
+ * @param {string} contents source code to check
+ * @param {string} filepath original absolute path to JS file the contents came from
+ * @returns {object}
+ */
+function findSourceMap(contents, filepath) {
+	const m = SOURCE_MAPPING_URL_REGEXP.exec(contents);
+	if (!m) {
+		return null;
+	}
+
+	let lastMatch = m.pop();
+	// HANDLE inlined data: source maps!
+	if (lastMatch.startsWith('data:')) {
+		const parts = lastMatch.split(';');
+		const contents = parts[2];
+		if (contents.startsWith('base64,')) {
+			const map = JSON.parse(Buffer.from(contents.slice(7), 'base64').toString('utf-8'));
+			return {
+				map,
+				filepath
+			};
+		}
+		// if starts with file://, drop that
+	} else if (lastMatch.startsWith('file://')) {
+		lastMatch = lastMatch.slice(7);
+	}
+	// resolve filepath relative to the original input JS file if we need to...
+	const mapFile = path.resolve(path.dirname(filepath), lastMatch);
+
+	const map = fs.readJSONSync(mapFile);
+	return {
+		map,
+		filepath: mapFile
+	};
+}
 
 /**
  * Analyzes an HTML file for all app:// JavaScript files

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -159,10 +159,11 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 	const transformed = babel.transformFromAstSync(ast, contents, options);
 	results.contents = transformed.code;
 	if (opts.sourceMap) {
-		results.contents += `\n//# sourceMappingURL=${path.basename(opts.dest)}.map`;
+		// point to the original source file and the source map file
+		results.contents += `\n//# sourceURL=file://${opts.filename}\n//# sourceMappingURL=file://${opts.dest}.map\n`;
 		// Drop the sourcesContent property from the map, as the map already contains the filepath of the input source file
 		delete transformed.map.sourcesContent;
-		// TODO: Do we need to retian the sourcesContent for device builds?
+		// TODO: Do we need to retain the sourcesContent for device builds?
 		transformed.map.file = opts.dest; // give it the destination file path as 'file' so Studio and other parsers can handle it
 		fs.writeFileSync(opts.dest + '.map', JSON.stringify(transformed.map));
 	}

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -147,24 +147,30 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 		options.plugins.push.apply(options.plugins, opts.plugins);
 	}
 
-	// generate a source map
-	// we spit out a .map file next to the JS file and append a comment ot the JS code
-	// to point at the map file using sourceMappingURL
+	// generate an inline source map
+	// we inline the source map because iOS web inspector can't access the original source file/map
+	// and we may not have access to the original file once on device
 	if (opts.sourceMap) {
 		options.sourceMaps = true;
-		options.sourceFileName = opts.filename;
-	}
+		// DO NOT set sourceFileName to real source file path, it will break iOS,
+		// and while Android works (and then we can eliminate sourcesContent from map)
+		// it leads to an odd folder listing split between the generated file and original file
+		// Instead, we set the relative filename
 
+		// It looks like the source of iOS issues is when the sourceFileName is not an *exact* match for the basename of the file
+		// Why iOS/Safari shows scripts only by their basename instead of the relative path in-app, or the absolute url we give it, I don't know
+	}
 	const transformed = babel.transformFromAstSync(ast, contents, options);
 	results.contents = transformed.code;
 	if (opts.sourceMap) {
-		// point to the original source file and the source map file
-		results.contents += `\n//# sourceURL=file://${opts.filename}\n//# sourceMappingURL=file://${opts.dest}.map\n`;
-		// Drop the sourcesContent property from the map, as the map already contains the filepath of the input source file
-		delete transformed.map.sourcesContent;
-		// TODO: Do we need to retain the sourcesContent for device builds?
-		transformed.map.file = opts.dest; // give it the destination file path as 'file' so Studio and other parsers can handle it
-		fs.writeFileSync(opts.dest + '.map', JSON.stringify(transformed.map));
+		// DO NOT DELETE transformed.map.sourcesContent! Because we don't point to the real absolute filepath of the source file
+		// the JS debugger *cannot* load the contents itself!
+		// Do our own inlined source map so we can have control over the map object that is written!
+		const base64Contents = Buffer.from(JSON.stringify(transformed.map)).toString('base64');
+		// ensure posix style file separators, turn into file:// URI, encode as URI
+		const sourceURL = encodeURI(`file://${opts.filename.replace(/\\/g, '/')}`);
+		// NOTE: We MUST append a \n or else iOS will break, because it injects a ';' after the original file contents when doing it's require() impl
+		results.contents += `//# sourceURL=${sourceURL}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Contents}\n`;
 	}
 	results.symbols = Array.from(apiTracker.symbols.values()); // convert Set values to Array
 

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -14,7 +14,6 @@
 'use strict';
 
 const appc = require('node-appc');
-const path = require('path');
 const fs = require('fs-extra');
 const DOMParser = require('xmldom').DOMParser;
 const babel = require('@babel/core');

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -14,6 +14,7 @@
 'use strict';
 
 const appc = require('node-appc');
+const path = require('path');
 const fs = require('fs-extra');
 const DOMParser = require('xmldom').DOMParser;
 const babel = require('@babel/core');
@@ -147,14 +148,24 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 		options.plugins.push.apply(options.plugins, opts.plugins);
 	}
 
-	// generate and inline source map
-	// we inline the source map as the map cannot be retreived from the device
-	// using the inspector protocol. only parsed .js files can be retreived.
+	// generate a source map
+	// we spit out a .map file next to the JS file and append a comment ot the JS code
+	// to point at the map file using sourceMappingURL
 	if (opts.sourceMap) {
-		options.sourceMaps = 'inline';
+		options.sourceMaps = true;
+		options.sourceFileName = opts.filename;
 	}
 
-	results.contents = babel.transformFromAstSync(ast, contents, options).code;
+	const transformed = babel.transformFromAstSync(ast, contents, options);
+	results.contents = transformed.code;
+	if (opts.sourceMap) {
+		results.contents += `\n//# sourceMappingURL=${path.basename(opts.dest)}.map`;
+		// Drop the sourcesContent property from the map, as the map already contains the filepath of the input source file
+		delete transformed.map.sourcesContent;
+		// TODO: Do we need to retian the sourcesContent for device builds?
+		transformed.map.file = opts.dest; // give it the destination file path as 'file' so Studio and other parsers can handle it
+		fs.writeFileSync(opts.dest + '.map', JSON.stringify(transformed.map));
+	}
 	results.symbols = Array.from(apiTracker.symbols.values()); // convert Set values to Array
 
 	return results;

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -170,7 +170,7 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 		// ensure posix style file separators, turn into file:// URI, encode as URI
 		const sourceURL = encodeURI(`file://${opts.filename.replace(/\\/g, '/')}`);
 		// NOTE: We MUST append a \n or else iOS will break, because it injects a ';' after the original file contents when doing it's require() impl
-		results.contents += `//# sourceURL=${sourceURL}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Contents}\n`;
+		results.contents += `\n//# sourceURL=${sourceURL}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Contents}\n`;
 	}
 	results.symbols = Array.from(apiTracker.symbols.values()); // convert Set values to Array
 

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -56,6 +56,7 @@ exports.analyzeJsFile = function analyzeJsFile(file, opts = {}) {
  * @param {String} contents - A string of JavaScript
  * @param {Object} [opts] - Analyze options
  * @param {String} [opts.filename] - The filename of the original JavaScript source
+ * @param {String} [opts.dest] full filepath of the destination JavaScript file we'll write the contents to
  * @param {Boolean} [opts.minify=false] - If true, minifies the JavaScript and returns it
  * @param {Boolean} [opts.transpile=false] - If true, transpiles the JS code and retuns it
  * @param {Array} [opts.plugins=[]] - An array of resolved Babel plugins
@@ -150,7 +151,7 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 		options.plugins.push.apply(options.plugins, opts.plugins);
 	}
 
-	let sourceFileName = opts.filename; // sued to poitn to correct original source in sources/sourceRoot of final source map
+	let sourceFileName = opts.filename; // used to point to correct original source in sources/sourceRoot of final source map
 	// generate a source map
 	if (opts.sourceMap) {
 		// we manage the source maps ourselves rather than just choose 'inline'
@@ -177,18 +178,9 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 					existingMap.sourceRoot = existingMap.sourceRoot.slice(7);
 				}
 				sourceFileName = path.resolve(existingMap.sourceRoot, sourceFileName);
-				delete existingMap.sourceRoot; // drop the sourceRoot here so it doesn't get passed along, may break iOS/Web Inspector
 			}
 			// if sourceFilename is still not absolute, resolve relative to map file
 			sourceFileName = path.resolve(path.dirname(mapFile), sourceFileName);
-
-			delete existingMap.file; // ignore the intermediate filename, don't pass it along as we'll use our own name
-
-			// Inject sourcesContent of original file contents into the source map
-			existingMap.sourcesContent = [ fs.readFileSync(sourceFileName, 'utf-8') ];
-
-			// Strip sources to base names so they get matched up properly in debugger script listing
-			existingMap.sources = existingMap.sources.map(s => path.basename(s));
 
 			// ok, we've mangled the source map enough for babel to consume it
 			options.inputSourceMap = existingMap;
@@ -200,12 +192,30 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 	if (opts.sourceMap) {
 		// Drop the original sourceMappingURL comment (for alloy files)
 		results.contents = results.contents.replace(SOURCE_MAPPING_URL_REGEXP, '');
+
 		// Point the sourceRoot at the original dir (so the full filepath of the original source can be gleaned from sources/sourceRoot combo)
-		transformed.map.sourceRoot = path.dirname(sourceFileName);
+		// we already have a sourceRoot in the case of an input source map - so don't override that
+		if (!transformed.map.sourceRoot) {
+			transformed.map.sourceRoot = path.dirname(sourceFileName);
+		}
 		// Android / Chrome DevTools is sane and can load the source from disk
 		// so we can ditch inlining the original source there (I'm looking at you Safari/WebInspector!)
 		if (opts.platform === 'android') {
+			// NOTE that this will drop some of the alloy template code too. If we want users to see the original source from that, don't delete this!
+			// Or alternatively, make alloy report the real template filename in it's source mapping
 			delete transformed.map.sourcesContent;
+		} else {
+			// if they didn't specify the final filepath, assume the js file's base name won't change from the source one (it shouldn't)
+			const generatedBasename = path.basename(opts.dest || opts.filename);
+			transformed.map.sources = transformed.map.sources.map(s => {
+				const sourceBasename = path.basename(s);
+				return sourceBasename === generatedBasename ? sourceBasename : s;
+			});
+			// FIXME: on iOS/Safari - If there are multiple sources, any sources whose basename matches the generated file basename
+			// will get their parent path listed as a folder, but WILL NOT SHOW THE FILE!
+			// How in the world do we fix this?
+			// Well, if there's only one source with the same basename and we rename it to just the basename, that "fixes" the Web Inspector display
+			// IDEA: What if we fix iOS to report URIs like /app.js as Android does, will that make it behave more properly?
 		}
 
 		// Do our own inlined source map so we can have control over the map object that is written!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "3.1.2",
+	"version": "3.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "3.1.2",
+	"version": "3.2.0",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -52,5 +52,28 @@ describe('jsanalyze', function () {
 			const results = jsanalyze.analyzeJs('async function other() { return 1; }; async function first() { const result = await other(); return result + 3; };', { transpile: true, minify: true, targets: { ios: 8 } });
 			results.contents.should.eql('function asyncGeneratorStep(gen,resolve,reject,_next,_throw,key,arg){try{var info=gen[key](arg),value=info.value}catch(error){return void reject(error)}info.done?resolve(value):Promise.resolve(value).then(_next,_throw)}function _asyncToGenerator(fn){return function(){var self=this,args=arguments;return new Promise(function(resolve,reject){function _next(value){asyncGeneratorStep(gen,resolve,reject,_next,_throw,"next",value)}function _throw(err){asyncGeneratorStep(gen,resolve,reject,_next,_throw,"throw",err)}var gen=fn.apply(self,args);_next(void 0)})}}function other(){return _other.apply(this,arguments)}function _other(){return _other=_asyncToGenerator(regeneratorRuntime.mark(function _callee(){return regeneratorRuntime.wrap(function _callee$(_context){for(;1;)switch(_context.prev=_context.next){case 0:return _context.abrupt("return",1);case 1:case"end":return _context.stop();}},_callee)})),_other.apply(this,arguments)};function first(){return _first.apply(this,arguments)}function _first(){return _first=_asyncToGenerator(regeneratorRuntime.mark(function _callee2(){var result;return regeneratorRuntime.wrap(function _callee2$(_context2){for(;1;)switch(_context2.prev=_context2.next){case 0:return _context2.next=2,other();case 2:return result=_context2.sent,_context2.abrupt("return",result+3);case 4:case"end":return _context2.stop();}},_callee2)})),_first.apply(this,arguments)};');
 		});
+
+		it('generates source maps alongside js file', function () {
+			const mapFile = path.join(__dirname, 'output.js.map');
+			const outputJSFile = path.join(__dirname, 'output.js');
+			try {
+				const results = jsanalyze.analyzeJs('var myGlobalMethod = function() { return this; };',
+					{
+						transpile: true,
+						sourceMap: true,
+						dest: outputJSFile,
+						filename: 'input.js'
+					});
+				results.contents.should.eql('var myGlobalMethod = function myGlobalMethod() {return this;};\n//# sourceMappingURL=output.js.map');
+				fs.pathExistsSync(mapFile).should.eql(true);
+				const sourceMap = fs.readJsonSync(mapFile);
+				sourceMap.file.should.eql(outputJSFile);
+				sourceMap.sources.should.be.an.Array;
+				sourceMap.sources[0].should.eql('input.js');
+			} finally {
+				fs.removeSync(mapFile);
+			}
+		});
+
 	});
 });

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -53,16 +53,42 @@ describe('jsanalyze', function () {
 			results.contents.should.eql('function asyncGeneratorStep(gen,resolve,reject,_next,_throw,key,arg){try{var info=gen[key](arg),value=info.value}catch(error){return void reject(error)}info.done?resolve(value):Promise.resolve(value).then(_next,_throw)}function _asyncToGenerator(fn){return function(){var self=this,args=arguments;return new Promise(function(resolve,reject){function _next(value){asyncGeneratorStep(gen,resolve,reject,_next,_throw,"next",value)}function _throw(err){asyncGeneratorStep(gen,resolve,reject,_next,_throw,"throw",err)}var gen=fn.apply(self,args);_next(void 0)})}}function other(){return _other.apply(this,arguments)}function _other(){return _other=_asyncToGenerator(regeneratorRuntime.mark(function _callee(){return regeneratorRuntime.wrap(function _callee$(_context){for(;1;)switch(_context.prev=_context.next){case 0:return _context.abrupt("return",1);case 1:case"end":return _context.stop();}},_callee)})),_other.apply(this,arguments)};function first(){return _first.apply(this,arguments)}function _first(){return _first=_asyncToGenerator(regeneratorRuntime.mark(function _callee2(){var result;return regeneratorRuntime.wrap(function _callee2$(_context2){for(;1;)switch(_context2.prev=_context2.next){case 0:return _context2.next=2,other();case 2:return result=_context2.sent,_context2.abrupt("return",result+3);case 4:case"end":return _context2.stop();}},_callee2)})),_first.apply(this,arguments)};');
 		});
 
-		it('generates source maps alongside js file', function () {
-			const outputJSFile = path.join(__dirname, 'output.js');
+		it('generates source maps inline js file', function () {
+			const inputJSFile = path.join(__dirname, 'resources/input.js');
 			const results = jsanalyze.analyzeJs('var myGlobalMethod = function() { return this; };',
 				{
 					transpile: true,
 					sourceMap: true,
-					dest: outputJSFile,
-					filename: 'input.js'
+					filename: inputJSFile
 				});
-			results.contents.should.eql('var myGlobalMethod = function myGlobalMethod() {return this;};\n//# sourceURL=file://input.js\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sIm5hbWVzIjpbIm15R2xvYmFsTWV0aG9kIl0sIm1hcHBpbmdzIjoiQUFBQSxJQUFJQSxjQUFjLEdBQUcsU0FBakJBLGNBQWlCLEdBQVcsQ0FBRSxPQUFPLElBQVAsQ0FBYyxDQUFoRCIsInNvdXJjZXNDb250ZW50IjpbInZhciBteUdsb2JhbE1ldGhvZCA9IGZ1bmN0aW9uKCkgeyByZXR1cm4gdGhpczsgfTsiXX0=\n');
+			// eslint-disable-next-line max-len
+			results.contents.should.eql(`var myGlobalMethod = function myGlobalMethod() {return this;};\n//# sourceURL=file://${inputJSFile}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sIm5hbWVzIjpbIm15R2xvYmFsTWV0aG9kIl0sIm1hcHBpbmdzIjoiQUFBQSxJQUFJQSxjQUFjLEdBQUcsU0FBakJBLGNBQWlCLEdBQVcsQ0FBRSxPQUFPLElBQVAsQ0FBYyxDQUFoRCIsInNvdXJjZXNDb250ZW50IjpbInZhciBteUdsb2JhbE1ldGhvZCA9IGZ1bmN0aW9uKCkgeyByZXR1cm4gdGhpczsgfTsiXX0=\n`);
+		});
+
+		it('handles input JS file with existing sourceMappingURL pointing to file', function () {
+			const inputMapFile = path.join(__dirname, 'resources/input.js.map');
+			const inputJSFile = path.join(__dirname, 'resources/input.js');
+			const results = jsanalyze.analyzeJs(`var myGlobalMethod = function() { return this; };\n//# sourceMappingURL=file://${inputMapFile}`,
+				{
+					transpile: true,
+					sourceMap: true,
+					filename: 'intermediate.js'
+				});
+			// eslint-disable-next-line max-len
+			results.contents.should.eql(`var myGlobalMethod = function myGlobalMethod() {return this;};\n\n//# sourceURL=file://${inputJSFile}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sIm5hbWVzIjpbIm15R2xvYmFsTWV0aG9kIl0sIm1hcHBpbmdzIjoiQUFBQSxJQUFJQSxjQUFjLEdBQWRBLFNBQUFBLGNBQUFBLEdBQUFBLENBQUFBLE9BQUFBLElBQUFBLENBQUosQ0FBQSIsInNvdXJjZXNDb250ZW50IjpbInZhciBteUdsb2JhbE1ldGhvZCA9IGZ1bmN0aW9uKCkgeyByZXR1cm4gdGhpczsgfTsiXX0=\n`);
+		});
+
+		it('handles input JS file with existing sourceMappingURL with data: uri', function () {
+			// given that it's inlined, it will try to resolve the relative 'input.js' source as relative to the JS filename we pass along in options.
+			const inputJSFile = path.join(__dirname, 'resources/input.js');
+			const results = jsanalyze.analyzeJs('var myGlobalMethod = function() { return this; };\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sIm5hbWVzIjpbIm15R2xvYmFsTWV0aG9kIl0sIm1hcHBpbmdzIjoiQUFBQSxJQUFJQSxjQUFjLEdBQUcsU0FBakJBLGNBQWlCLEdBQVcsQ0FBRSxPQUFPLElBQVAsQ0FBYyxDQUFoRCIsInNvdXJjZXNDb250ZW50IjpbInZhciBteUdsb2JhbE1ldGhvZCA9IGZ1bmN0aW9uKCkgeyByZXR1cm4gdGhpczsgfTsiXX0=',
+				{
+					transpile: true,
+					sourceMap: true,
+					filename: path.join(__dirname, 'resources/intermediate.js')
+				});
+			// eslint-disable-next-line max-len
+			results.contents.should.eql(`var myGlobalMethod = function myGlobalMethod() {return this;};\n\n//# sourceURL=file://${inputJSFile}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sIm5hbWVzIjpbIm15R2xvYmFsTWV0aG9kIl0sIm1hcHBpbmdzIjoiQUFBQSxJQUFJQSxjQUFjLEdBQWRBLFNBQUFBLGNBQUFBLEdBQUFBLENBQUFBLE9BQUFBLElBQUFBLENBQUosQ0FBQSIsInNvdXJjZXNDb250ZW50IjpbInZhciBteUdsb2JhbE1ldGhvZCA9IGZ1bmN0aW9uKCkgeyByZXR1cm4gdGhpczsgfTsiXX0=\n`);
 		});
 
 	});

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -64,7 +64,7 @@ describe('jsanalyze', function () {
 						dest: outputJSFile,
 						filename: 'input.js'
 					});
-				results.contents.should.eql('var myGlobalMethod = function myGlobalMethod() {return this;};\n//# sourceMappingURL=output.js.map');
+				results.contents.should.eql(`var myGlobalMethod = function myGlobalMethod() {return this;};\n//# sourceURL=file://input.js\n//# sourceMappingURL=file://${__dirname}/output.js.map\n`);
 				fs.pathExistsSync(mapFile).should.eql(true);
 				const sourceMap = fs.readJsonSync(mapFile);
 				sourceMap.file.should.eql(outputJSFile);

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -54,25 +54,15 @@ describe('jsanalyze', function () {
 		});
 
 		it('generates source maps alongside js file', function () {
-			const mapFile = path.join(__dirname, 'output.js.map');
 			const outputJSFile = path.join(__dirname, 'output.js');
-			try {
-				const results = jsanalyze.analyzeJs('var myGlobalMethod = function() { return this; };',
-					{
-						transpile: true,
-						sourceMap: true,
-						dest: outputJSFile,
-						filename: 'input.js'
-					});
-				results.contents.should.eql(`var myGlobalMethod = function myGlobalMethod() {return this;};\n//# sourceURL=file://input.js\n//# sourceMappingURL=file://${__dirname}/output.js.map\n`);
-				fs.pathExistsSync(mapFile).should.eql(true);
-				const sourceMap = fs.readJsonSync(mapFile);
-				sourceMap.file.should.eql(outputJSFile);
-				sourceMap.sources.should.be.an.Array;
-				sourceMap.sources[0].should.eql('input.js');
-			} finally {
-				fs.removeSync(mapFile);
-			}
+			const results = jsanalyze.analyzeJs('var myGlobalMethod = function() { return this; };',
+				{
+					transpile: true,
+					sourceMap: true,
+					dest: outputJSFile,
+					filename: 'input.js'
+				});
+			results.contents.should.eql('var myGlobalMethod = function myGlobalMethod() {return this;};\n//# sourceURL=file://input.js\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sIm5hbWVzIjpbIm15R2xvYmFsTWV0aG9kIl0sIm1hcHBpbmdzIjoiQUFBQSxJQUFJQSxjQUFjLEdBQUcsU0FBakJBLGNBQWlCLEdBQVcsQ0FBRSxPQUFPLElBQVAsQ0FBYyxDQUFoRCIsInNvdXJjZXNDb250ZW50IjpbInZhciBteUdsb2JhbE1ldGhvZCA9IGZ1bmN0aW9uKCkgeyByZXR1cm4gdGhpczsgfTsiXX0=\n');
 		});
 
 	});

--- a/tests/resources/input.js
+++ b/tests/resources/input.js
@@ -1,0 +1,1 @@
+var myGlobalMethod = function() { return this; };

--- a/tests/resources/input.js.map
+++ b/tests/resources/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["input.js"],"names":["myGlobalMethod"],"mappings":"AAAA,IAAIA,cAAc,GAAG,SAAjBA,cAAiB,GAAW,CAAE,OAAO,IAAP,CAAc,CAAhD","sourcesContent":["var myGlobalMethod = function() { return this; };"]}

--- a/tests/resources/intermediate.js.map
+++ b/tests/resources/intermediate.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["input.js"],"names":["myGlobalMethod"],"mappings":"AAAA,IAAIA,cAAc,GAAdA,SAAAA,cAAAA,GAAAA,CAAAA,OAAAA,IAAAA,CAAJ,CAAA","sourcesContent":["var myGlobalMethod = function() { return this; };"]}


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-27098

**Description**
Modifies our behavior with source maps.

The net result of all my testing is this:
- iOS blows up if the source map's `"sources: ["filename.js"]"` name is not the base name of the JS file. Presumably because it has to match the script name it shows for the generated/in-app file (which is just the base name). If they don't match but it's able to load the source map, it'll show a folder child for the script, but it will be empty and the source mapping is busted. There's probably some more work to do digging here. We report full file URIs with absolute paths to the JS engine under the hood for iOS. Maybe using relative (to app root) paths would fix that? We report URI paths that looks absolute but are relative to the app's Resources folder on Android.
- Our require implementation for iOS wraps the original content injecting a `;` right after it, which is why it couldn't load the inlined source maps as-is. I worked around this by writing the inlined source maps ourselves with extra newlines around it.
- Android is happy to use the script's reported `//# sourceURL=file:///path/to/source.js` value even if the source map has just the base name of the file (as iOS needs). It then organizes the sources!

I tested this on Android Emulator and iOS Simulator, **but not devices**

![Screen Shot 2019-06-11 at 3 53 10 PM](https://user-images.githubusercontent.com/3252/59302835-e1884a80-8c62-11e9-8b5a-a99bd30aa300.png)
![Screen Shot 2019-06-11 at 3 51 37 PM](https://user-images.githubusercontent.com/3252/59302836-e1884a80-8c62-11e9-9630-486506bbb149.png)
