### PR TITLE
feat(jsanalyze): integrate babel-plugin-transform-titanium

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -40,8 +40,13 @@ exports.getAPIUsage = function getAPIUsage() {
  *
  * @param {String} file - The full path to the JavaScript file
  * @param {Object} [opts] - Analyze options
- * @param {String} [opts.filename] - The filename of the original JavaScript source
  * @param {Boolean} [opts.minify=false] - If true, minifies the JavaScript and returns it
+ * @param {String} [opts.dest] full filepath of the destination JavaScript file we'll write the contents to
+ * @param {Boolean} [opts.minify=false] - If true, minifies the JavaScript and returns it
+ * @param {Boolean} [opts.transpile=false] - If true, transpiles the JS code and retuns it
+ * @param {Array} [opts.plugins=[]] - An array of resolved Babel plugins
+ * @param {Function} [opts.logger] - Logger instance to use for logging warnings.
+ * @param {object} [opts.transform={}] - object holding static values about the app/platform/build for the babel titanium transform plugin
  * @returns {Object} An object containing symbols and minified JavaScript
  * @throws {Error} An error if unable to parse the JavaScript
  */
@@ -61,11 +66,13 @@ exports.analyzeJsFile = function analyzeJsFile(file, opts = {}) {
  * @param {Boolean} [opts.transpile=false] - If true, transpiles the JS code and retuns it
  * @param {Array} [opts.plugins=[]] - An array of resolved Babel plugins
  * @param {Function} [opts.logger] - Logger instance to use for logging warnings.
+ * @param {object} [opts.transform={}] - object holding static values about the app/platform/build for the babel titanium transform plugin
  * @returns {Object} An object containing symbols and minified JavaScript
  * @throws {Error} An error if unable to parse the JavaScript
  */
 exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 	opts.plugins || (opts.plugins = []);
+	opts.transform || (opts.transform = {});
 
 	// parse the js file
 	let ast;
@@ -127,6 +134,7 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 	// transpile
 	if (opts.transpile) {
 		options.plugins.push(require.resolve('./babel-plugins/global-this'));
+		options.plugins.push([ require.resolve('babel-plugin-transform-titanium'), opts.transform ]);
 		options.presets.push([ env, { targets: opts.targets } ]);
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1776,6 +1776,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
 			"integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
 		},
+		"babel-plugin-transform-titanium": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-titanium/-/babel-plugin-transform-titanium-0.1.1.tgz",
+			"integrity": "sha512-N2ImhDNsfmT5Q68HeNJfg1xE8Z3NsVYWC+/TWLtckscXPjleDJRciIRzhUhI6876VXhxSjbw5s7ylv1NTa/xoA=="
+		},
 		"babel-plugin-transform-undefined-to-void": {
 			"version": "6.9.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"@babel/plugin-transform-property-literals": "^7.2.0",
 		"@babel/preset-env": "^7.6.3",
 		"async": "^3.1.0",
+		"babel-plugin-transform-titanium": "^0.1.1",
 		"babel-preset-minify": "^0.5.1",
 		"colors": "^1.3.3",
 		"fs-extra": "^8.1.0",

--- a/tests/jsanalyze_test.js
+++ b/tests/jsanalyze_test.js
@@ -131,5 +131,11 @@ describe('jsanalyze', function () {
 			const expectedBase64Map = Buffer.from(JSON.stringify(expectedSourceMap)).toString('base64');
 			results.contents.should.eql(`var myGlobalMethod = function myGlobalMethod() {return this;};\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${expectedBase64Map}\n`);
 		});
+
+		// babel-plugin-transform-titanium
+		it('converts OS_IOS into boolean', () => {
+			const results = jsanalyze.analyzeJs('if (OS_IOS) {}', { transpile: true, transform: { platform: 'ios' } });
+			results.contents.should.eql('if (true) {}');
+		});
 	});
 });


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-27167

**Description**
Integrates [appcelerator/babel-plugin-transform-titanium](https://github.com/appcelerator/babel-plugin-transform-titanium) 0.1.1

Will require changes to [appcelerator/titanium_mobile](https://github.com/appcelerator/titanium_mobile) to pass along the options used by the plugin.

The goal here is pass along an object with static values about the target platform/app that our custom babel plugin can use to inline the static values and replace typical platform sniffing expressions. (As well as do some of what appcelerator/alloy has done in it's compile for years, like having special `OS_*`, `DIST_*`, `ENV_*` defines). See the plugin's [README](https://github.com/appcelerator/babel-plugin-transform-titanium/blob/master/README.md) for more details.