### PR TITLE
fix(android): emulator fails to launch

### DIFF
--- a/lib/emulators/avd.js
+++ b/lib/emulators/avd.js
@@ -225,7 +225,7 @@ exports.start = function start(config, emu, opts, callback) {
 				});
 
 				socket.on('error', function (err) {
-					if (err.errno === 'ECONNREFUSED') {
+					if (err.code === 'ECONNREFUSED') {
 						// port available!
 						if (socket) {
 							socket.end();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"


### PR DESCRIPTION
- Emulator fails to launch as it's unable to find a valid port
- Error code property `error.errno` should only return numeric values, `error.code` should be used instead

##### TEST CASE
- Attempt to build Titanium application for emulator
- Emulator should launch successfully and application will build

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27723)