### PR TITLE
feat(android): update android ndk folder detection

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -181,6 +181,41 @@ exports.detect = function detect(config, opts, finished) {
 				}
 			]);
 
+			// Check under the NDK side-by-side directory which contains multiple NDK installations.
+			// Each subfolder is named after the version of NDK installed under it. Favor the newest version.
+			{
+				const pathDictionary = {
+					darwin: '~/Library/Android/sdk/ndk',
+					linux: '~/Android/sdk/ndk',
+					win32: '%LOCALAPPDATA%\\Android\\Sdk\\ndk'
+				};
+				let ndkPath = pathDictionary[process.platform];
+				if (ndkPath) {
+					ndkPath = afs.resolvePath(ndkPath);
+					if (fs.existsSync(ndkPath) && fs.statSync(ndkPath).isDirectory()) {
+						let fileNames = fs.readdirSync(ndkPath);
+						fileNames.sort(versionStringSortComparer);
+						fileNames = fileNames.reverse();
+						for (const nextFileName of fileNames) {
+							const nextFilePath = path.join(ndkPath, nextFileName);
+							queue.push(function (cb) {
+								findNDK(nextFilePath, config, cb);
+							});
+						}
+					}
+				}
+			}
+
+			// Check for an "ndk-bundle" folder under Android SDK folder. (Deprecated as of 2019.)
+			queue.push(function (cb) {
+				const pathDictionary = {
+					darwin: '~/Library/Android/sdk/ndk-bundle',
+					linux: '~/Android/sdk/ndk-bundle',
+					win32: '%LOCALAPPDATA%\\Android\\Sdk\\ndk-bundle'
+				};
+				findNDK(pathDictionary[process.platform], config, cb);
+			});
+
 			// scan various paths
 			var dirs = process.platform == 'win32'
 				? ['%SystemDrive%', '%ProgramFiles%', '%ProgramFiles(x86)%', '%CommonProgramFiles%', '~']
@@ -1062,4 +1097,51 @@ function loadAddon(dir, platforms, systemImages) {
 		androidJar:  basedOn && basedOn.androidJar || null,
 		aidl:        basedOn && basedOn.aidl || null
 	};
+}
+
+function versionStringSortComparer(element1, element2) {
+	// Check if the references match. (This is an optimization.)
+	// eslint-disable-next-line eqeqeq
+	if (element1 == element2) {
+		return 0;
+	}
+
+	// Compare element types. String types are always greater than non-string types.
+	const isElement1String = (typeof element1 === 'string');
+	const isElement2String = (typeof element2 === 'string');
+	if (isElement1String && !isElement2String) {
+		return 1;
+	} else if (!isElement1String && isElement2String) {
+		return -1;
+	} else if (!isElement1String && !isElement2String) {
+		return 0;
+	}
+
+	// Split version strings into components. Example: '1.2.3' -> ['1', '2', '3']
+	// If there is version component length mismatch, then pad the rest with zeros.
+	const version1Components = element1.split('.');
+	const version2Components = element2.split('.');
+	const componentLengthDelta = version1Components.length - version2Components.length;
+	if (componentLengthDelta > 0) {
+		version2Components.push(...Array(componentLengthDelta).fill('0'));
+	} else if (componentLengthDelta < 0) {
+		version1Components.push(...Array(-componentLengthDelta).fill('0'));
+	}
+
+	// Compare the 2 given version strings by their numeric components.
+	for (let index = 0; index < version1Components.length; index++) {
+		let value1 = Number.parseInt(version1Components[index], 10);
+		if (Number.isNaN(value1)) {
+			value1 = 0;
+		}
+		let value2 = Number.parseInt(version2Components[index], 10);
+		if (Number.isNaN(value2)) {
+			value2 = 0;
+		}
+		const valueDelta = value1 - value2;
+		if (valueDelta !== 0) {
+			return valueDelta;
+		}
+	}
+	return 0;
 }


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27755

**Summary:**
- Added NDK side-by-side folder lookup.
  * This is where Android Studio currently installs NDK as of 2019.
  * This folder contains multiple NDK installations.
- Added "ndk-bundle" folder lookup.
  * This used to be where Android Studio installed the NDK. (Deprecated in 2019.)
