### PR TITLE
fix: obfuscate source map line construction

### DIFF
--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -231,8 +231,12 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 
 			// Do our own inlined source map so we can have control over the map object that is written!
 			const base64Contents = Buffer.from(JSON.stringify(transformed.map)).toString('base64');
-			// NOTE: We MUST append a \n or else iOS will break, because it injects a ';' after the original file contents when doing it's require() impl
-			results.contents += `\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${base64Contents}\n`;
+			// NOTE: We MUST append a \n or else iOS will break, because it injects a ';' after the
+			// original file contents when doing it's require() impl
+			// NOTE: Construction of the source-map url needs to be obfuscated to avoid unwanted
+			// detection of this line as an actual source-map by `source-map-support` package.
+			const sourceMapPrefix = 'sourceMappingURL=data:application/json;charset=utf-8;base64';
+			results.contents += `\n//# ${sourceMapPrefix},${base64Contents}\n`;
 		}
 	}
 	results.symbols = Array.from(apiTracker.symbols.values()); // convert Set values to Array

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"titanium",
 		"mobile"
 	],
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"author": {
 		"name": "Appcelerator, Inc.",
 		"email": "info@appcelerator.com"
@@ -103,7 +103,7 @@
 	},
 	"commitlint": {
 		"extends": [
-		  "@commitlint/config-conventional"
+			"@commitlint/config-conventional"
 		]
 	}
 }


### PR DESCRIPTION
The [source-map-support](https://github.com/evanw/node-source-map-support#readme) package falsely identifies the `//# sourceMappingUrl=` line that we add to the transpiled code as the actual source mapping for the `jsanalyze.js` file. This leads to a nasty crash that hides the original error when `source-map-support` is enabled and it tries to read a non-existent source map while preparing the original error stack trace.

```sh
SyntaxError: Unexpected token m in JSON at position 0
        at JSON.parse (<anonymous>)

      at Object.parseSourceMapInput (../../node_modules/source-map/lib/util.js:433:15)
      at new SourceMapConsumer (../../node_modules/source-map/lib/source-map-consumer.js:17:22)
      at mapSourcePosition (../../node_modules/source-map-support/source-map-support.js:200:14)
      at wrapCallSite (../../node_modules/source-map-support/source-map-support.js:377:20)
      at Function.prepareStackTrace (../../node_modules/source-map-support/source-map-support.js:426:39)
```

Obfuscating the construction of the source map line so that the regex defined [here](https://github.com/evanw/node-source-map-support/blob/d29e9c81527346b6ec385f7ba27a7a1c487b69c7/source-map-support.js#L150) doesn't match fixes the issue.

