### PR TITLE
fix(android): build on 64bit Linux fails if no 32bit libs available

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -486,12 +486,6 @@ ADB.prototype.trackDevices = function trackDevices(callback) {
  */
 function androidDetect(config, callback) {
 	(require('./android')).detect(config, null, function (results) {
-		for (var i = 0, l = results.issues.length; i < l; i++) {
-			if (results.issues[i].id === 'ANDROID_MISSING_32BIT_LIBS') {
-				return callback(new Error(results.issues[i].message));
-			}
-		}
-
 		if (results.sdk && results.sdk.executables.adb) {
 			callback(null, results);
 		} else {

--- a/lib/android.js
+++ b/lib/android.js
@@ -374,51 +374,6 @@ exports.detect = function detect(config, opts, finished) {
 						+ __('You may be able to fix it by reinstalling your graphics drivers and make sure it installs the 32-bit version.')
 				});
 			}
-
-			if (results.linux64bit.i386arch === false) {
-				results.issues.push({
-					id: 'ANDROID_MISSING_I386_ARCH',
-					type: 'warning',
-					message: __('i386 architecture is not configured.') + '\n'
-						+ __('To ensure you install the required 32-bit libraries, you need to register the i386 architecture with dpkg.') + '\n'
-						+ __('To add the i386 architecture, run "%s".', '__sudo dpkg --add-architecture i386__')
-				});
-			}
-
-			var missing32bitLibs = [];
-			results.linux64bit['libc6:i386'] === false && missing32bitLibs.push('libc6:i386');
-			results.linux64bit['libncurses5:i386'] === false && missing32bitLibs.push('libncurses5:i386');
-			results.linux64bit['libstdc++6:i386'] === false && missing32bitLibs.push('libstdc++6:i386');
-			results.linux64bit['zlib1g:i386'] === false && missing32bitLibs.push('zlib1g:i386');
-			if (missing32bitLibs.length) {
-				results.issues.push({
-					id: 'ANDROID_MISSING_32BIT_LIBS',
-					type: 'error',
-					message: __('32-bit libraries is not installed.') + '\n'
-						+ __('Without the 32-bit libraries, the Android SDK will not work properly.') + '\n'
-						+ __('To install the required 32-bit libraries, run "%s".', '__sudo apt-get install ' + missing32bitLibs.join(' ') + '__')
-				});
-			}
-
-			if (results.linux64bit.glibc === false) {
-				results.issues.push({
-					id: 'ANDROID_MISSING_32BIT_GLIBC',
-					type: 'warning',
-					message: __('32-bit glibc library is not installed.') + '\n'
-						+ __('Without the 32-bit glibc library, the Android Emulator will not work properly.') + '\n'
-						+ __('To install the required 32-bit glibc library, run "%s".', '__sudo yum install glibc.i686__')
-				});
-			}
-
-			if (results.linux64bit.libstdcpp === false) {
-				results.issues.push({
-					id: 'ANDROID_MISSING_32BIT_LIBSTDCPP',
-					type: 'warning',
-					message: __('32-bit libstdc++ library is not installed.') + '\n'
-						+ __('Without the 32-bit libstdc++ library, the Android Emulator will not work properly.') + '\n'
-						+ __('To install the required 32-bit libstdc++ library, run "%s".', '__sudo yum install libstdc++.i686__')
-				});
-			}
 		}
 
 		if (!results.ndk) {


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28496

**Note:**
The Android SDK's tools and emulator are 64-bit now. We no longer need to check for 32-bit libraries like this anymore.

**Test:**
Build and run a Titanium app project on 64-bit Linux to the Android emulator.