### PR TITLE
No longer require tooling that has been removed and/or is no longer referenced by the SDK build

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -25,15 +25,10 @@ const fs = require('fs'),
 	findExecutable = appc.subprocess.findExecutable,
 	exe = process.platform === 'win32' ? '.exe' : '',
 	cmd = process.platform === 'win32' ? '.cmd' : '',
-	bat = process.platform === 'win32' ? '.bat' : '',
 	commandPrefix = process.env.APPC_ENV ? 'appc ' : '',
 	requiredSdkTools = {
 		adb: exe,
-		emulator: exe,
-		mksdcard: exe,
-		zipalign: exe,
-		aapt: exe,
-		aidl: exe
+		emulator: exe
 	},
 	pkgPropRegExp = /^([^=]*)=\s*(.+)$/;
 
@@ -750,15 +745,7 @@ function findSDK(dir, config, androidPackageJson, callback) {
 			path: dir,
 			executables: {
 				adb:       path.join(dir, 'platform-tools', 'adb' + exe),
-				android:   null, // this tool has been deprecated
-				emulator:  fs.existsSync(emulatorPath) ? emulatorPath : path.join(dir, 'tools', 'emulator' + exe),
-				mksdcard:  path.join(dir, 'tools', 'mksdcard' + exe),
-				zipalign:  path.join(dir, 'tools', 'zipalign' + exe),
-				// Android SDK Tools v21 and older puts aapt and aidl in the platform-tools dir.
-				// For SDK Tools v22 and later, they live in the build-tools/<ver> directory.
-				aapt:      path.join(dir, 'platform-tools', 'aapt' + exe),
-				aidl:      path.join(dir, 'platform-tools', 'aidl' + exe),
-				apksigner: null
+				emulator:  fs.existsSync(emulatorPath) ? emulatorPath : path.join(dir, 'tools', 'emulator' + exe)
 			},
 			proguard: fs.existsSync(proguardPath) ? proguardPath : null,
 			tools: {
@@ -828,10 +815,6 @@ function findSDK(dir, config, androidPackageJson, callback) {
 						tooNew: buildToolsSupported,
 						maxSupported: appc.version.parseMax(androidPackageJson.vendorDependencies['android build tools'], true)
 					};
-					fs.existsSync(file = path.join(buildToolsDir, ver, 'aapt' + exe)) && (result.executables.aapt = file);
-					fs.existsSync(file = path.join(buildToolsDir, ver, 'aidl' + exe)) && (result.executables.aidl = file);
-					fs.existsSync(file = path.join(buildToolsDir, ver, 'apksigner' + bat)) && (result.executables.apksigner = file);
-					fs.existsSync(file = path.join(buildToolsDir, ver, 'zipalign' + exe)) && (result.executables.zipalign = file);
 				}
 			} else {
 				// build tools don't exist at the given location

--- a/lib/android.js
+++ b/lib/android.js
@@ -33,8 +33,7 @@ const fs = require('fs'),
 		mksdcard: exe,
 		zipalign: exe,
 		aapt: exe,
-		aidl: exe,
-		dx: bat
+		aidl: exe
 	},
 	pkgPropRegExp = /^([^=]*)=\s*(.+)$/;
 
@@ -745,8 +744,7 @@ function findSDK(dir, config, androidPackageJson, callback) {
 		return callback(true);
 	}
 
-	const dxJarPath = path.join(dir, 'platform-tools', 'lib', 'dx.jar'),
-		proguardPath = path.join(dir, 'tools', 'proguard', 'lib', 'proguard.jar'),
+	const proguardPath = path.join(dir, 'tools', 'proguard', 'lib', 'proguard.jar'),
 		emulatorPath = path.join(dir, 'emulator', 'emulator' + exe),
 		result = {
 			path: dir,
@@ -760,10 +758,8 @@ function findSDK(dir, config, androidPackageJson, callback) {
 				// For SDK Tools v22 and later, they live in the build-tools/<ver> directory.
 				aapt:      path.join(dir, 'platform-tools', 'aapt' + exe),
 				aidl:      path.join(dir, 'platform-tools', 'aidl' + exe),
-				dx:        path.join(dir, 'platform-tools', 'dx' + bat),
 				apksigner: null
 			},
-			dx: fs.existsSync(dxJarPath) ? dxJarPath : null,
 			proguard: fs.existsSync(proguardPath) ? proguardPath : null,
 			tools: {
 				path: null,
@@ -835,8 +831,6 @@ function findSDK(dir, config, androidPackageJson, callback) {
 					fs.existsSync(file = path.join(buildToolsDir, ver, 'aapt' + exe)) && (result.executables.aapt = file);
 					fs.existsSync(file = path.join(buildToolsDir, ver, 'aidl' + exe)) && (result.executables.aidl = file);
 					fs.existsSync(file = path.join(buildToolsDir, ver, 'apksigner' + bat)) && (result.executables.apksigner = file);
-					fs.existsSync(file = path.join(buildToolsDir, ver, 'dx' + bat)) && (result.executables.dx = file);
-					fs.existsSync(file = path.join(buildToolsDir, ver, 'lib', 'dx.jar')) && (result.dx = file);
 					fs.existsSync(file = path.join(buildToolsDir, ver, 'zipalign' + exe)) && (result.executables.zipalign = file);
 				}
 			} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-titanium-sdk",
-	"version": "5.1.4",
+	"version": "5.1.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "titanium",
     "mobile"
   ],
-  "version": "5.1.4",
+  "version": "5.1.5",
   "author": {
     "name": "Appcelerator, Inc.",
     "email": "info@appcelerator.com"

--- a/tests/adb_test.js
+++ b/tests/adb_test.js
@@ -107,6 +107,11 @@ describe('adb', function () {
 
 		after(function (finished) {
 			this.timeout(35000);
+			// Just call finished if there is no device, there may have been an issue when starting
+			// the emulator in the before
+			if (!device) {
+				return finished();
+			}
 			emulator.stop(device.emulator.id, function (errOrCode) {
 				errOrCode.should.eql(0);
 				setTimeout(finished, 5000); // let it wait 5 seconds or else adb will still report it as connected

--- a/tests/avd_test.js
+++ b/tests/avd_test.js
@@ -84,7 +84,7 @@ describe('emulator', function () {
 
 		it('#start(), #isRunning() and #stop()', function (finished) {
 			this.slow(30000);
-			this.timeout(90000);
+			this.timeout(180000);
 
 			emulator.start(avd.id, function (err, emu) {
 				if (err) {

--- a/tests/avd_test.js
+++ b/tests/avd_test.js
@@ -91,13 +91,13 @@ describe('emulator', function () {
 					return finished(err);
 				}
 
-				emu.should.be.ok;
+				emu.should.be.ok();
 
 				emu.on('ready', function (device) {
-					device.should.be.ok;
+					device.should.be.ok();
 
 					emulator.isRunning(device.emulator.id, function (err, emu) {
-						emu.should.be.ok;
+						emu.should.be.ok();
 
 						emulator.stop(device.emulator.id, function (errOrCode) {
 							errOrCode.should.eql(0);

--- a/tests/avd_test.js
+++ b/tests/avd_test.js
@@ -101,7 +101,7 @@ describe('emulator', function () {
 
 						emulator.stop(device.emulator.id, function (errOrCode) {
 							errOrCode.should.eql(0);
-							finished(); // TODO wait 5 seconds here or else future start call that quickly follows will get messed up!. See adb_test
+							setTimeout(finished, 5000); // let it wait 5 seconds or else adb will still report it as connected
 						});
 					});
 				});


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-28519

Removes the requirement for the dx tool (removed in the API 31 install) and the also removes the tools no longer directly referenced in the SDK build scripts.

This will need a follow up on the Titanium CLI repo to no longer as that checks that they exist in the `ti setup check` command, no breakage seen in Studio