### PR TITLE
feat(all): add -l for --log-level

### DIFF
--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -43,6 +43,7 @@ exports.allPlatformNames = [ 'android', 'ios', 'iphone', 'ipad', 'mobileweb', 'b
 exports.commonOptions = function (logger, config) {
 	return {
 		'log-level': {
+			abbr: 'l',
 			callback: function (value) {
 				Object.prototype.hasOwnProperty.call(logger.levels, value) && logger.setLevel(value);
 			},


### PR DESCRIPTION
Make it possible to use `-l debug` instead of `--log-level debug`

![Screenshot_20211101_163819](https://user-images.githubusercontent.com/4334997/139698584-53ce766e-19f7-4a88-99e0-387f495bd076.png)
