### PR TITLE
chore: update search path

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -726,7 +726,7 @@ function findSDK(dir, config, androidPackageJson, callback) {
 		return callback(true);
 	}
 
-	const emulatorPath = path.join(dir, 'emulator', 'emulator' + exe),
+	const emulatorPath = path.join(dir, 'emulator', `emulator${exe}`),
 		result = {
 			path: dir,
 			executables: {


### PR DESCRIPTION
as far as my test show this is the only part that is left so it still needs the obsolete Android SDK Tools folder:

![Screenshot144](https://user-images.githubusercontent.com/4334997/215773514-7870596c-5b68-425c-a3ee-a266fbe98455.png)

in fact: building apps already works fine, just `ti info` complains about `Unable to locate an Android SDK.`

Tested building to device and emulator, building a module and apk